### PR TITLE
Fix CertificateResource.NamesKeys() truncation

### DIFF
--- a/certmagic.go
+++ b/certmagic.go
@@ -412,7 +412,7 @@ func (cr *CertificateResource) NamesKey() string {
 	sort.Strings(cr.SANs)
 	result := strings.Join(cr.SANs, ",")
 	if len(result) > 1024 {
-		result = result[1018:] + "_trunc"
+		result = result[:1024-len("_trunc")] + "_trunc"
 	}
 	return result
 }


### PR DESCRIPTION
Fix for https://github.com/caddyserver/certmagic/issues/64

