### PR TITLE
Lock now takes a context and should honor cancellation

### DIFF
--- a/config.go
+++ b/config.go
@@ -388,7 +388,7 @@ func (cfg *Config) obtainWithIssuer(ctx context.Context, issuer Issuer, name str
 
 	// ensure idempotency of the obtain operation for this name
 	lockKey := cfg.lockKey("cert_acme", name)
-	err := obtainLock(ctx, cfg.Storage, lockKey)
+	err := acquireLock(ctx, cfg.Storage, lockKey)
 	if err != nil {
 		return err
 	}
@@ -474,7 +474,7 @@ func (cfg *Config) renewWithIssuer(ctx context.Context, issuer Issuer, name stri
 
 	// ensure idempotency of the renew operation for this name
 	lockKey := cfg.lockKey("cert_acme", name)
-	err := obtainLock(ctx, cfg.Storage, lockKey)
+	err := acquireLock(ctx, cfg.Storage, lockKey)
 	if err != nil {
 		return err
 	}

--- a/config.go
+++ b/config.go
@@ -388,7 +388,7 @@ func (cfg *Config) obtainWithIssuer(ctx context.Context, issuer Issuer, name str
 
 	// ensure idempotency of the obtain operation for this name
 	lockKey := cfg.lockKey("cert_acme", name)
-	err := obtainLock(cfg.Storage, lockKey)
+	err := obtainLock(ctx, cfg.Storage, lockKey)
 	if err != nil {
 		return err
 	}
@@ -474,7 +474,7 @@ func (cfg *Config) renewWithIssuer(ctx context.Context, issuer Issuer, name stri
 
 	// ensure idempotency of the renew operation for this name
 	lockKey := cfg.lockKey("cert_acme", name)
-	err := obtainLock(cfg.Storage, lockKey)
+	err := obtainLock(ctx, cfg.Storage, lockKey)
 	if err != nil {
 		return err
 	}

--- a/filestorage.go
+++ b/filestorage.go
@@ -15,6 +15,7 @@
 package certmagic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -124,7 +125,7 @@ func (fs *FileStorage) Filename(key string) string {
 
 // Lock obtains a lock named by the given key. It blocks
 // until the lock can be obtained or an error is returned.
-func (fs *FileStorage) Lock(key string) error {
+func (fs *FileStorage) Lock(ctx context.Context, key string) error {
 	filename := fs.lockFilename(key)
 
 	for {
@@ -168,8 +169,13 @@ func (fs *FileStorage) Lock(key string) error {
 
 		default:
 			// lockfile exists and is not stale;
-			// just wait a moment and try again
-			time.Sleep(fileLockPollInterval)
+			// just wait a moment and try again,
+			// or return if context cancelled
+			select {
+			case <-time.After(fileLockPollInterval):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
 	}
 }

--- a/storage.go
+++ b/storage.go
@@ -227,7 +227,7 @@ func CleanUpOwnLocks() {
 	}
 }
 
-func obtainLock(ctx context.Context, storage Storage, lockKey string) error {
+func acquireLock(ctx context.Context, storage Storage, lockKey string) error {
 	err := storage.Lock(ctx, lockKey)
 	if err == nil {
 		locksMu.Lock()


### PR DESCRIPTION
This allows callers to give up if they can't obtain a lock in a certain
timeframe and for resources to be cleaned up, avoiding potential
resource leaks.

Breaking change for any Storage implementations, sorry about that. (It's
why we're not 1.0 yet.) I'll reach out to known implementations; it's a
simple change.