### PR TITLE
chore: update go version declared in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caddyserver/certmagic
 
-go 1.13
+go 1.14
 
 require (
 	github.com/go-acme/lego/v3 v3.7.0


### PR DESCRIPTION
Function handshake.DefaultCertificateSelector uses the field
`*tls.ClientHelloInfo.SupportsCertificate` which only supported in go 1.14