### PR TITLE
Add a way to configure cert loading from the storage

### DIFF
--- a/certmagic.go
+++ b/certmagic.go
@@ -247,7 +247,7 @@ func ManageAsync(ctx context.Context, domainNames []string) error {
 // containing the names passed into those functions if
 // no DecisionFunc is set. This ensures some degree of
 // control by default to avoid certificate operations for
-// aribtrary domain names. To override this whitelist,
+// arbitrary domain names. To override this whitelist,
 // manually specify a DecisionFunc. To impose rate limits,
 // specify your own DecisionFunc.
 type OnDemandConfig struct {
@@ -283,6 +283,20 @@ func (o *OnDemandConfig) whitelistContains(name string) bool {
 		}
 	}
 	return false
+}
+
+type StorageLoadConfig struct {
+	// Wildcard certificates in the form of *.domain.com
+	// will also be attempted to load from the storage.
+	// This had a performance impact as an extra call to
+	// the storage will be done.
+	TryWildcard bool
+
+	// Wildcard certificates with multiple levels like
+	// *.*.domain.com also be attempted to load from the storage.
+	// This had a performance impact as multiple extra call to
+	// the storage will be done.
+	TryMultiLevelWildcard bool
 }
 
 // isLoopback returns true if the hostname of addr looks

--- a/config.go
+++ b/config.go
@@ -93,6 +93,11 @@ type Config struct {
 	// loading TLS assets
 	Storage Storage
 
+	// The rules that define how certificates are loaded
+	// from the storage;
+	// if nil, only exact match will be tried
+	StorageLoad *StorageLoadConfig
+
 	// required pointer to the in-memory cert cache
 	certCache *Cache
 }

--- a/handshake_test.go
+++ b/handshake_test.go
@@ -25,7 +25,11 @@ func TestGetCertificate(t *testing.T) {
 		cache:      make(map[string]Certificate),
 		cacheIndex: make(map[string][]string),
 	}
-	cfg := &Config{certCache: c}
+	cfg := &Config{
+		Issuer:    &ACMEManager{CA: "https://example.com/acme/directory"},
+		Storage:   &FileStorage{Path: "./_testdata_tmp"},
+		certCache: c,
+	}
 
 	// create a test connection for conn.LocalAddr()
 	l, _ := net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
This is a proposal PR to address https://github.com/caddyserver/certmagic/issues/76

Note: I don't fully understand the assumption made in CertMagic so this might be incorrect/problematic in some places. I also didn't fully test it. This PR is to show what changes I suggest.

In term of DX, changes are as follow:
- the OnDemand concept is restricted to generating certs from the CA instead of this + loading from storage
- an extra configuration struct is added to control how storage certs are loaded
- exact match certificates are still loaded as previously
- loading multi-level wildcard certificates is gated by an extra config flag to avoid the performance penalty, even if you want to load wildcard certificates