### PR TITLE
Minor improvement to DNS request handling

### DIFF
--- a/dnsutil.go
+++ b/dnsutil.go
@@ -143,13 +143,12 @@ func createDNSMsg(fqdn string, rtype uint16, recursive bool) *dns.Msg {
 func sendDNSQuery(m *dns.Msg, ns string) (*dns.Msg, error) {
 	udp := &dns.Client{Net: "udp", Timeout: dnsTimeout}
 	in, _, err := udp.Exchange(m, ns)
-
-  var truncated = (in != nil && in.Truncated)
-  var timeout_err = (err != nil && strings.Contains(err.Error(), "timeout"))
-
-  if truncated || timeout_err {
+	// two kinds of errors we can handle by retrying with TCP:
+	// truncation and timeout; see https://github.com/caddyserver/caddy/issues/3639
+	truncated := in != nil && in.Truncated
+	timeoutErr := err != nil && strings.Contains(err.Error(), "timeout")
+	if truncated || timeoutErr {
 		tcp := &dns.Client{Net: "tcp", Timeout: dnsTimeout}
-		// If the TCP request succeeds, the err will reset to nil
 		in, _, err = tcp.Exchange(m, ns)
 	}
 	return in, err

--- a/dnsutil.go
+++ b/dnsutil.go
@@ -143,7 +143,11 @@ func createDNSMsg(fqdn string, rtype uint16, recursive bool) *dns.Msg {
 func sendDNSQuery(m *dns.Msg, ns string) (*dns.Msg, error) {
 	udp := &dns.Client{Net: "udp", Timeout: dnsTimeout}
 	in, _, err := udp.Exchange(m, ns)
-	if in != nil && in.Truncated {
+
+  var truncated = (in != nil && in.Truncated)
+  var timeout_err = (err != nil && strings.Contains(err.Error(), "timeout"))
+
+  if truncated || timeout_err {
 		tcp := &dns.Client{Net: "tcp", Timeout: dnsTimeout}
 		// If the TCP request succeeds, the err will reset to nil
 		in, _, err = tcp.Exchange(m, ns)


### PR DESCRIPTION
Sometimes incoming udp traffic on port 53 is blocked to prevent DDoS attacks. In those cases only TCP will work for DNS request as the UDP request will time out. And as a result the DNS challenge will fail, while the server is trying to verify if the challenge was propageted through the NS.

Now instead of returning immidently, if a timeout with UDP was received, the request will be tried again using TCP.