### PR TITLE
dnsutil: replace fmt.Sprintf() with err.Error() when formatting errors

### DIFF
--- a/dnsutil.go
+++ b/dnsutil.go
@@ -160,7 +160,7 @@ func formatDNSError(msg *dns.Msg, err error) string {
 		parts = append(parts, dns.RcodeToString[msg.Rcode])
 	}
 	if err != nil {
-		parts = append(parts, fmt.Sprintf("%v", err))
+		parts = append(parts, err.Error())
 	}
 	if len(parts) > 0 {
 		return ": " + strings.Join(parts, " ")


### PR DESCRIPTION
### What does this PR do?

Replaces an error to string coversion using `fmt.Sprintf` by calling `Error()` method on that error.

### What does it improve?

Code readability.

### How was it tested?

`go test -race -v ./...`

### What Go version did you use when testing it?

`1.15` and `tip`.

