### PR TITLE
account: handle decodePrivateKey() error in getAccount

### DIFF
--- a/account.go
+++ b/account.go
@@ -54,6 +54,9 @@ func (am *ACMEManager) getAccount(ca, email string) (acme.Account, error) {
 		return acct, err
 	}
 	acct.PrivateKey, err = decodePrivateKey(keyBytes)
+	if err != nil {
+		return acct, fmt.Errorf("could not decode account's private key: %v", err)
+	}
 
 	// TODO: July 2020 - transition to new ACME lib and account structure;
 	// for a while, we will need to convert old accounts to new structure


### PR DESCRIPTION
### What does this PR do?

Handles `decodePrivateKey` error and returns after adding some context to it. See https://github.com/caddyserver/certmagic/blob/4fd8ae48ef87c9fd8917659cfb53aac98f48ecac/account.go#L56

### What does it improve?

Until now, error was silently ignored. It should be handled or explicitly ignored. Now, if we fail to decode user's private key, they will know.

Please, feel free to close this PR if you disagree.

Fixes #88.

### How was it tested?

`go test -race -v ./...`

### What Go version did you use when testing it?

`1.15` and `tip`.


