### PR TITLE
Implement multiple issuer support

### DIFF
--- a/account.go
+++ b/account.go
@@ -242,8 +242,12 @@ func (am *ACMEManager) askUserAgreement(agreementURL string) bool {
 	return answer == "y" || answer == "yes"
 }
 
+func storageKeyACMECAPrefix(issuerKey string) string {
+	return path.Join(prefixACME, StorageKeys.Safe(issuerKey))
+}
+
 func (am *ACMEManager) storageKeyCAPrefix(caURL string) string {
-	return path.Join(prefixACME, StorageKeys.Safe(am.issuerKey(caURL)))
+	return storageKeyACMECAPrefix(am.issuerKey(caURL))
 }
 
 func (am *ACMEManager) storageKeyUsersPrefix(caURL string) string {

--- a/account_test.go
+++ b/account_test.go
@@ -27,7 +27,7 @@ import (
 func TestNewAccount(t *testing.T) {
 	am := &ACMEManager{CA: dummyCA}
 	testConfig := &Config{
-		Issuer:    am,
+		Issuers:   []Issuer{am},
 		Storage:   &FileStorage{Path: "./_testdata_tmp"},
 		certCache: new(Cache),
 	}
@@ -52,7 +52,7 @@ func TestNewAccount(t *testing.T) {
 func TestSaveAccount(t *testing.T) {
 	am := &ACMEManager{CA: dummyCA}
 	testConfig := &Config{
-		Issuer:    am,
+		Issuers:   []Issuer{am},
 		Storage:   &FileStorage{Path: "./_testdata1_tmp"},
 		certCache: new(Cache),
 	}
@@ -85,7 +85,7 @@ func TestSaveAccount(t *testing.T) {
 func TestGetAccountDoesNotAlreadyExist(t *testing.T) {
 	am := &ACMEManager{CA: dummyCA}
 	testConfig := &Config{
-		Issuer:    am,
+		Issuers:   []Issuer{am},
 		Storage:   &FileStorage{Path: "./_testdata_tmp"},
 		certCache: new(Cache),
 	}
@@ -104,7 +104,7 @@ func TestGetAccountDoesNotAlreadyExist(t *testing.T) {
 func TestGetAccountAlreadyExists(t *testing.T) {
 	am := &ACMEManager{CA: dummyCA}
 	testConfig := &Config{
-		Issuer:    am,
+		Issuers:   []Issuer{am},
 		Storage:   &FileStorage{Path: "./_testdata2_tmp"},
 		certCache: new(Cache),
 	}
@@ -155,7 +155,7 @@ func TestGetEmailFromPackageDefault(t *testing.T) {
 
 	am := &ACMEManager{CA: dummyCA}
 	testConfig := &Config{
-		Issuer:    am,
+		Issuers:   []Issuer{am},
 		Storage:   &FileStorage{Path: "./_testdata2_tmp"},
 		certCache: new(Cache),
 	}
@@ -174,7 +174,7 @@ func TestGetEmailFromPackageDefault(t *testing.T) {
 func TestGetEmailFromUserInput(t *testing.T) {
 	am := &ACMEManager{CA: dummyCA}
 	testConfig := &Config{
-		Issuer:    am,
+		Issuers:   []Issuer{am},
 		Storage:   &FileStorage{Path: "./_testdata3_tmp"},
 		certCache: new(Cache),
 	}
@@ -206,7 +206,7 @@ func TestGetEmailFromUserInput(t *testing.T) {
 func TestGetEmailFromRecent(t *testing.T) {
 	am := &ACMEManager{CA: dummyCA}
 	testConfig := &Config{
-		Issuer:    am,
+		Issuers:   []Issuer{am},
 		Storage:   &FileStorage{Path: "./_testdata4_tmp"},
 		certCache: new(Cache),
 	}

--- a/acmeclient.go
+++ b/acmeclient.go
@@ -153,12 +153,12 @@ func (am *ACMEManager) newACMEClient(ctx context.Context, useTestCA, interactive
 				useHTTPPort = am.AltHTTPPort
 			}
 			client.ChallengeSolvers[acme.ChallengeTypeHTTP01] = distributedSolver{
-				acmeManager: am,
+				storage:                am.config.Storage,
+				storageKeyIssuerPrefix: am.storageKeyCAPrefix(client.Directory),
 				solver: &httpSolver{
 					acmeManager: am,
 					address:     net.JoinHostPort(am.ListenHost, strconv.Itoa(useHTTPPort)),
 				},
-				caURL: client.Directory,
 			}
 		}
 
@@ -172,12 +172,12 @@ func (am *ACMEManager) newACMEClient(ctx context.Context, useTestCA, interactive
 				useTLSALPNPort = am.AltTLSALPNPort
 			}
 			client.ChallengeSolvers[acme.ChallengeTypeTLSALPN01] = distributedSolver{
-				acmeManager: am,
+				storage:                am.config.Storage,
+				storageKeyIssuerPrefix: am.storageKeyCAPrefix(client.Directory),
 				solver: &tlsALPNSolver{
 					config:  am.config,
 					address: net.JoinHostPort(am.ListenHost, strconv.Itoa(useTLSALPNPort)),
 				},
-				caURL: client.Directory,
 			}
 		}
 	} else {

--- a/acmemanager.go
+++ b/acmemanager.go
@@ -108,8 +108,9 @@ type ACMEManager struct {
 // DefaultACME, and if any required values are still empty, sensible
 // defaults will be used.
 //
-// Typically, you'll create the Config first, then call NewACMEManager(),
-// then assign the return value to the Issuer/Revoker fields of the Config.
+// Typically, you'll create the Config first with New() or NewDefault(),
+// then call NewACMEManager(), then assign the return value to the Issuers
+// field of the Config.
 func NewACMEManager(cfg *Config, template ACMEManager) *ACMEManager {
 	if cfg == nil {
 		panic("cannot make valid ACMEManager without an associated CertMagic config")

--- a/acmemanager.go
+++ b/acmemanager.go
@@ -19,7 +19,7 @@ import (
 // Issuer, and Revoker interfaces.
 //
 // It is NOT VALID to use an ACMEManager without calling NewACMEManager().
-// It fills in default values from DefaultACME as well as setting up
+// It fills in any default values from DefaultACME as well as setting up
 // internal state that is necessary for valid use. Always call
 // NewACMEManager() to get a valid ACMEManager value.
 type ACMEManager struct {
@@ -105,7 +105,8 @@ type ACMEManager struct {
 
 // NewACMEManager constructs a valid ACMEManager based on a template
 // configuration; any empty values will be filled in by defaults in
-// DefaultACME. The associated config is also required.
+// DefaultACME, and if any required values are still empty, sensible
+// defaults will be used.
 //
 // Typically, you'll create the Config first, then call NewACMEManager(),
 // then assign the return value to the Issuer/Revoker fields of the Config.
@@ -301,8 +302,7 @@ func (am *ACMEManager) doIssue(ctx context.Context, csr *x509.CertificateRequest
 		return nil, usingTestCA, fmt.Errorf("%v %w (ca=%s)", nameSet, err, client.acmeClient.Directory)
 	}
 
-	// TODO: ACME server could in theory issue a cert with multiple chains,
-	// but we don't (yet) have a way to choose one, so just use first one
+	// TODO: ACME server could in theory issue a cert with multiple chains, but we don't (yet) have a way to choose one, so just use first one
 	ic := &IssuedCertificate{
 		Certificate: certChains[0].ChainPEM,
 		Metadata:    certChains[0],
@@ -326,8 +326,8 @@ func (am *ACMEManager) Revoke(ctx context.Context, cert CertificateResource, rea
 	return client.revoke(ctx, certs[0], reason)
 }
 
-// DefaultACME specifies the default settings
-// to use for ACMEManagers.
+// DefaultACME specifies default settings to use for ACMEManagers.
+// Using this value is optional but can be convenient.
 var DefaultACME = ACMEManager{
 	CA:     LetsEncryptProductionCA,
 	TestCA: LetsEncryptStagingCA,
@@ -337,6 +337,7 @@ var DefaultACME = ACMEManager{
 const (
 	LetsEncryptStagingCA    = "https://acme-staging-v02.api.letsencrypt.org/directory"
 	LetsEncryptProductionCA = "https://acme-v02.api.letsencrypt.org/directory"
+	ZeroSSLProductionCA     = "https://acme.zerossl.com/v2/DV90"
 )
 
 // prefixACME is the storage key prefix used for ACME-specific assets.

--- a/acmemanager.go
+++ b/acmemanager.go
@@ -177,7 +177,7 @@ func (am *ACMEManager) IssuerKey() string {
 	return am.issuerKey(am.CA)
 }
 
-func (am *ACMEManager) issuerKey(ca string) string {
+func (*ACMEManager) issuerKey(ca string) string {
 	key := ca
 	if caURL, err := url.Parse(key); err == nil {
 		key = caURL.Host

--- a/config.go
+++ b/config.go
@@ -54,45 +54,40 @@ type Config struct {
 
 	// DefaultServerName specifies a server name
 	// to use when choosing a certificate if the
-	// ClientHello's ServerName field is empty
+	// ClientHello's ServerName field is empty.
 	DefaultServerName string
 
 	// The state needed to operate on-demand TLS;
 	// if non-nil, on-demand TLS is enabled and
 	// certificate operations are deferred to
-	// TLS handshakes (or as-needed)
+	// TLS handshakes (or as-needed).
 	// TODO: Can we call this feature "Reactive/Lazy/Passive TLS" instead?
 	OnDemand *OnDemandConfig
 
-	// Add the must staple TLS extension to the CSR
+	// Adds the must staple TLS extension to the CSR.
 	MustStaple bool
 
-	// The type that issues certificates; the
-	// default Issuer is ACMEManager
-	Issuer Issuer
-
-	// The type that revokes certificates; must
-	// be configured in conjunction with the Issuer
-	// field such that both the Issuer and Revoker
-	// are related (because issuance information is
-	// required for revocation)
-	Revoker Revoker
+	// The source for getting new certificates; the
+	// default Issuer is ACMEManager. If multiple
+	// issuers are specified, they will be tried in
+	// turn until one succeeds.
+	Issuers []Issuer
 
 	// The source of new private keys for certificates;
-	// the default KeySource is StandardKeyGenerator
+	// the default KeySource is StandardKeyGenerator.
 	KeySource KeyGenerator
 
 	// CertSelection chooses one of the certificates
 	// with which the ClientHello will be completed;
 	// if not set, DefaultCertificateSelector will
-	// be used
+	// be used.
 	CertSelection CertificateSelector
 
-	// The storage to access when storing or
-	// loading TLS assets
+	// The storage to access when storing or loading
+	// TLS assets. Default is the local file system.
 	Storage Storage
 
-	// Set a logger to enable logging
+	// Set a logger to enable logging.
 	Logger *zap.Logger
 
 	// required pointer to the in-memory cert cache
@@ -116,6 +111,9 @@ type Config struct {
 // same, default certificate cache. All configs returned
 // by NewDefault() are based on the values of the fields of
 // Default at the time it is called.
+//
+// This is the only way to get a config that uses the
+// default certificate cache.
 func NewDefault() *Config {
 	defaultCacheMu.Lock()
 	if defaultCache == nil {
@@ -153,7 +151,7 @@ func NewDefault() *Config {
 // the vast majority of cases, there will be only a
 // single Config, thus the default cache (which always
 // uses the default Config) and default config will
-// suffice, and you should use New() instead.
+// suffice, and you should use NewDefault() instead.
 func New(certCache *Cache, cfg Config) *Config {
 	if certCache == nil {
 		panic("a certificate cache is required")
@@ -196,23 +194,11 @@ func newWithCache(certCache *Cache, cfg Config) *Config {
 	if cfg.Storage == nil {
 		cfg.Storage = Default.Storage
 	}
-	if cfg.Issuer == nil {
-		cfg.Issuer = Default.Issuer
-		if cfg.Issuer == nil {
-			// okay really, we need an issuer,
-			// that's kind of the point; most
-			// people would probably want ACME
-			cfg.Issuer = NewACMEManager(&cfg, DefaultACME)
-		}
-		// issuer and revoker go together; if user
-		// specifies their own issuer, we don't want
-		// to override their revoker, hence we only
-		// do this if Issuer was also nil
-		if cfg.Revoker == nil {
-			cfg.Revoker = Default.Revoker
-			if cfg.Revoker == nil {
-				cfg.Revoker = NewACMEManager(&cfg, DefaultACME)
-			}
+	if len(cfg.Issuers) == 0 {
+		cfg.Issuers = Default.Issuers
+		if len(cfg.Issuers) == 0 {
+			// at least one issuer is absolutely required
+			cfg.Issuers = []Issuer{NewACMEManager(&cfg, DefaultACME)}
 		}
 	}
 
@@ -223,7 +209,6 @@ func newWithCache(certCache *Cache, cfg Config) *Config {
 		cfg.Storage = defaultFileStorage
 	}
 
-	// ensure the unexported fields are valid
 	cfg.certCache = certCache
 
 	return &cfg
@@ -372,27 +357,19 @@ func (cfg *Config) manageOne(ctx context.Context, domainName string, async bool)
 // TODO: consider moving interactive param into the Config struct,
 // and maybe retry settings into the Config struct as well? (same for RenewCert)
 func (cfg *Config) ObtainCert(ctx context.Context, name string, interactive bool) error {
-	if cfg.storageHasCertResources(name) {
+	if cfg.storageHasCertResourcesAnyIssuer(name) {
 		return nil
 	}
-	issuer, err := cfg.getPrecheckedIssuer(ctx, []string{name}, interactive)
+	// ensure storage is writeable and readable
+	// TODO: this is not necessary every time; should only perform check once every so often for each storage, which may require some global state...
+	err := cfg.checkStorage()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed storage check: %v - storage is probably misconfigured", err)
 	}
-	if issuer == nil {
-		return nil
-	}
-	return cfg.obtainWithIssuer(ctx, issuer, name, interactive)
+	return cfg.obtainCert(ctx, name, interactive)
 }
 
-func loggerNamed(l *zap.Logger, name string) *zap.Logger {
-	if l == nil {
-		return nil
-	}
-	return l.Named(name)
-}
-
-func (cfg *Config) obtainWithIssuer(ctx context.Context, issuer Issuer, name string, interactive bool) error {
+func (cfg *Config) obtainCert(ctx context.Context, name string, interactive bool) error {
 	log := loggerNamed(cfg.Logger, "obtain")
 
 	if log != nil {
@@ -400,7 +377,7 @@ func (cfg *Config) obtainWithIssuer(ctx context.Context, issuer Issuer, name str
 	}
 
 	// ensure idempotency of the obtain operation for this name
-	lockKey := cfg.lockKey("cert_acme", name)
+	lockKey := cfg.lockKey(certIssueLockOp, name)
 	err := acquireLock(ctx, cfg.Storage, lockKey)
 	if err != nil {
 		return err
@@ -424,7 +401,7 @@ func (cfg *Config) obtainWithIssuer(ctx context.Context, issuer Issuer, name str
 
 	f := func(ctx context.Context) error {
 		// check if obtain is still needed -- might have been obtained during lock
-		if cfg.storageHasCertResources(name) {
+		if cfg.storageHasCertResourcesAnyIssuer(name) {
 			if log != nil {
 				log.Info("certificate already exists in storage", zap.String("identifier", name))
 			}
@@ -445,8 +422,24 @@ func (cfg *Config) obtainWithIssuer(ctx context.Context, issuer Issuer, name str
 			return err
 		}
 
-		issuedCert, err := issuer.Issue(ctx, csr)
+		// try to obtain from each issuer until we succeed
+		var issuedCert *IssuedCertificate
+		var issuerUsed Issuer
+		for _, issuer := range cfg.Issuers {
+			if prechecker, ok := issuer.(PreChecker); ok {
+				err = prechecker.PreCheck(ctx, []string{name}, interactive)
+				if err != nil {
+					continue
+				}
+			}
+			issuedCert, err = issuer.Issue(ctx, csr)
+			if err == nil {
+				issuerUsed = issuer
+				break
+			}
+		}
 		if err != nil {
+			// TODO: only the error from the last issuer will be returned, oh well?
 			return fmt.Errorf("[%s] Obtain: %w", name, err)
 		}
 
@@ -457,7 +450,7 @@ func (cfg *Config) obtainWithIssuer(ctx context.Context, issuer Issuer, name str
 			PrivateKeyPEM:  privKeyPEM,
 			IssuerData:     issuedCert.Metadata,
 		}
-		err = cfg.saveCertResource(certRes)
+		err = cfg.saveCertResource(issuerUsed, certRes)
 		if err != nil {
 			return fmt.Errorf("[%s] Obtain: saving assets: %v", name, err)
 		}
@@ -480,21 +473,29 @@ func (cfg *Config) obtainWithIssuer(ctx context.Context, issuer Issuer, name str
 	return err
 }
 
+func (cfg *Config) storageHasCertResourcesAnyIssuer(name string) bool {
+	for _, iss := range cfg.Issuers {
+		if cfg.storageHasCertResources(iss, name) {
+			return true
+		}
+	}
+	return false
+}
+
 // RenewCert renews the certificate for name using cfg. It stows the
 // renewed certificate and its assets in storage if successful. It
 // DOES NOT update the in-memory cache with the new certificate.
 func (cfg *Config) RenewCert(ctx context.Context, name string, interactive bool) error {
-	issuer, err := cfg.getPrecheckedIssuer(ctx, []string{name}, interactive)
+	// ensure storage is writeable and readable
+	// TODO: this is not necessary every time; should only perform check once every so often for each storage, which may require some global state...
+	err := cfg.checkStorage()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed storage check: %v - storage is probably misconfigured", err)
 	}
-	if issuer == nil {
-		return nil
-	}
-	return cfg.renewWithIssuer(ctx, issuer, name, interactive)
+	return cfg.renewCert(ctx, name, interactive)
 }
 
-func (cfg *Config) renewWithIssuer(ctx context.Context, issuer Issuer, name string, interactive bool) error {
+func (cfg *Config) renewCert(ctx context.Context, name string, interactive bool) error {
 	log := loggerNamed(cfg.Logger, "renew")
 
 	if log != nil {
@@ -502,7 +503,7 @@ func (cfg *Config) renewWithIssuer(ctx context.Context, issuer Issuer, name stri
 	}
 
 	// ensure idempotency of the renew operation for this name
-	lockKey := cfg.lockKey("cert_acme", name)
+	lockKey := cfg.lockKey(certIssueLockOp, name)
 	err := acquireLock(ctx, cfg.Storage, lockKey)
 	if err != nil {
 		return err
@@ -526,7 +527,7 @@ func (cfg *Config) renewWithIssuer(ctx context.Context, issuer Issuer, name stri
 
 	f := func(ctx context.Context) error {
 		// prepare for renewal (load PEM cert, key, and meta)
-		certRes, err := cfg.loadCertResource(name)
+		certRes, err := cfg.loadCertResourceAnyIssuer(name)
 		if err != nil {
 			return err
 		}
@@ -556,8 +557,24 @@ func (cfg *Config) renewWithIssuer(ctx context.Context, issuer Issuer, name stri
 			return err
 		}
 
-		issuedCert, err := issuer.Issue(ctx, csr)
+		// try to obtain from each issuer until we succeed
+		var issuedCert *IssuedCertificate
+		var issuerUsed Issuer
+		for _, issuer := range cfg.Issuers {
+			if prechecker, ok := issuer.(PreChecker); ok {
+				err = prechecker.PreCheck(ctx, []string{name}, interactive)
+				if err != nil {
+					continue
+				}
+			}
+			issuedCert, err = issuer.Issue(ctx, csr)
+			if err == nil {
+				issuerUsed = issuer
+				break
+			}
+		}
 		if err != nil {
+			// TODO: only the error from the last issuer will be returned, oh well?
 			return fmt.Errorf("[%s] Renew: %w", name, err)
 		}
 
@@ -568,7 +585,7 @@ func (cfg *Config) renewWithIssuer(ctx context.Context, issuer Issuer, name stri
 			PrivateKeyPEM:  certRes.PrivateKeyPEM,
 			IssuerData:     issuedCert.Metadata,
 		}
-		err = cfg.saveCertResource(newCertRes)
+		err = cfg.saveCertResource(issuerUsed, newCertRes)
 		if err != nil {
 			return fmt.Errorf("[%s] Renew: saving assets: %v", name, err)
 		}
@@ -619,43 +636,45 @@ func (cfg *Config) generateCSR(privateKey crypto.PrivateKey, sans []string) (*x5
 }
 
 // RevokeCert revokes the certificate for domain via ACME protocol. It requires
-// that cfg.Issuer is properly configured with the same issuer that issued the
+// that cfg.Issuers is properly configured with the same issuer that issued the
 // certificate being revoked. See RFC 5280 §5.3.1 for reason codes.
 func (cfg *Config) RevokeCert(ctx context.Context, domain string, reason int, interactive bool) error {
-	rev := cfg.Revoker
-	if rev == nil {
-		rev = Default.Revoker
-	}
+	for i, issuer := range cfg.Issuers {
+		issuerKey := issuer.IssuerKey()
 
-	certRes, err := cfg.loadCertResource(domain)
-	if err != nil {
-		return err
-	}
+		rev, ok := issuer.(Revoker)
+		if !ok {
+			return fmt.Errorf("issuer %d (%s) is not a Revoker", i, issuerKey)
+		}
 
-	issuerKey := cfg.Issuer.IssuerKey()
+		certRes, err := cfg.loadCertResource(issuer, domain)
+		if err != nil {
+			return err
+		}
 
-	if !cfg.Storage.Exists(StorageKeys.SitePrivateKey(issuerKey, domain)) {
-		return fmt.Errorf("private key not found for %s", certRes.SANs)
-	}
+		if !cfg.Storage.Exists(StorageKeys.SitePrivateKey(issuerKey, domain)) {
+			return fmt.Errorf("private key not found for %s", certRes.SANs)
+		}
 
-	err = rev.Revoke(ctx, certRes, reason)
-	if err != nil {
-		return err
-	}
+		err = rev.Revoke(ctx, certRes, reason)
+		if err != nil {
+			return fmt.Errorf("issuer %d (%s): %v", i, issuerKey, err)
+		}
 
-	cfg.emit("cert_revoked", domain)
+		cfg.emit("cert_revoked", domain)
 
-	err = cfg.Storage.Delete(StorageKeys.SiteCert(issuerKey, domain))
-	if err != nil {
-		return fmt.Errorf("certificate revoked, but unable to delete certificate file: %v", err)
-	}
-	err = cfg.Storage.Delete(StorageKeys.SitePrivateKey(issuerKey, domain))
-	if err != nil {
-		return fmt.Errorf("certificate revoked, but unable to delete private key: %v", err)
-	}
-	err = cfg.Storage.Delete(StorageKeys.SiteMeta(issuerKey, domain))
-	if err != nil {
-		return fmt.Errorf("certificate revoked, but unable to delete certificate metadata: %v", err)
+		err = cfg.Storage.Delete(StorageKeys.SiteCert(issuerKey, domain))
+		if err != nil {
+			return fmt.Errorf("certificate revoked, but unable to delete certificate file: %v", err)
+		}
+		err = cfg.Storage.Delete(StorageKeys.SitePrivateKey(issuerKey, domain))
+		if err != nil {
+			return fmt.Errorf("certificate revoked, but unable to delete private key: %v", err)
+		}
+		err = cfg.Storage.Delete(StorageKeys.SiteMeta(issuerKey, domain))
+		if err != nil {
+			return fmt.Errorf("certificate revoked, but unable to delete certificate metadata: %v", err)
+		}
 	}
 
 	return nil
@@ -690,29 +709,6 @@ func (cfg *Config) TLSConfig() *tls.Config {
 		CipherSuites:             preferredDefaultCipherSuites(),
 		PreferServerCipherSuites: true,
 	}
-}
-
-// getPrecheckedIssuer returns an Issuer with pre-checks
-// completed, if it is also a PreChecker. It also checks
-// that storage is functioning. If a nil Issuer is returned
-// with a nil error, that means to skip this operation
-// (not an error, just a no-op).
-func (cfg *Config) getPrecheckedIssuer(ctx context.Context, names []string, interactive bool) (Issuer, error) {
-	// ensure storage is writeable and readable
-	// TODO: this is not necessary every time; should only
-	// perform check once every so often for each storage,
-	// which may require some global state...
-	err := cfg.checkStorage()
-	if err != nil {
-		return nil, fmt.Errorf("failed storage check: %v - storage is probably misconfigured", err)
-	}
-	if prechecker, ok := cfg.Issuer.(PreChecker); ok {
-		err := prechecker.PreCheck(ctx, names, interactive)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return cfg.Issuer, nil
 }
 
 // checkStorage tests the storage by writing random bytes
@@ -758,8 +754,8 @@ func (cfg *Config) checkStorage() error {
 // associated with cfg's certificate cache has all the
 // resources related to the certificate for domain: the
 // certificate, the private key, and the metadata.
-func (cfg *Config) storageHasCertResources(domain string) bool {
-	issuerKey := cfg.Issuer.IssuerKey()
+func (cfg *Config) storageHasCertResources(issuer Issuer, domain string) bool {
+	issuerKey := issuer.IssuerKey()
 	certKey := StorageKeys.SiteCert(issuerKey, domain)
 	keyKey := StorageKeys.SitePrivateKey(issuerKey, domain)
 	metaKey := StorageKeys.SiteMeta(issuerKey, domain)
@@ -771,18 +767,19 @@ func (cfg *Config) storageHasCertResources(domain string) bool {
 // lockKey returns a key for a lock that is specific to the operation
 // named op being performed related to domainName and this config's CA.
 func (cfg *Config) lockKey(op, domainName string) string {
-	return fmt.Sprintf("%s_%s_%s", op, domainName, cfg.Issuer.IssuerKey())
+	return fmt.Sprintf("%s_%s", op, domainName)
 }
 
-// managedCertNeedsRenewal returns true if certRes is
-// expiring soon or already expired, or if the process
-// of checking the expiration returned an error.
+// managedCertNeedsRenewal returns true if certRes is expiring soon or already expired,
+// or if the process of decoding the cert and checking its expiration returned an error.
 func (cfg *Config) managedCertNeedsRenewal(certRes CertificateResource) (time.Duration, bool) {
-	cert, err := makeCertificate(certRes.CertificatePEM, certRes.PrivateKeyPEM)
+	certChain, err := parseCertsFromPEMBundle(certRes.CertificatePEM)
 	if err != nil {
 		return 0, true
 	}
-	return time.Until(cert.Leaf.NotAfter), cert.NeedsRenewal(cfg)
+	remaining := time.Until(certChain[0].NotAfter)
+	needsRenew := currentlyInRenewalWindow(certChain[0].NotBefore, certChain[0].NotAfter, cfg.RenewalWindowRatio)
+	return remaining, needsRenew
 }
 
 func (cfg *Config) emit(eventName string, data interface{}) {
@@ -792,10 +789,23 @@ func (cfg *Config) emit(eventName string, data interface{}) {
 	cfg.OnEvent(eventName, data)
 }
 
+func loggerNamed(l *zap.Logger, name string) *zap.Logger {
+	if l == nil {
+		return nil
+	}
+	return l.Named(name)
+}
+
 // CertificateSelector is a type which can select a certificate to use given multiple choices.
 type CertificateSelector interface {
 	SelectCertificate(*tls.ClientHelloInfo, []Certificate) (Certificate, error)
 }
+
+// certIssueLockOp is the name of the operation used
+// when naming a lock to make it mutually exclusive
+// with other certificate issuance operations for a
+// certain name.
+const certIssueLockOp = "issue_cert"
 
 // Constants for PKIX MustStaple extension.
 var (

--- a/config.go
+++ b/config.go
@@ -357,6 +357,9 @@ func (cfg *Config) manageOne(ctx context.Context, domainName string, async bool)
 // TODO: consider moving interactive param into the Config struct,
 // and maybe retry settings into the Config struct as well? (same for RenewCert)
 func (cfg *Config) ObtainCert(ctx context.Context, name string, interactive bool) error {
+	if len(cfg.Issuers) == 0 {
+		return fmt.Errorf("no issuers configured; impossible to obtain or check for existing certificate in storage")
+	}
 	if cfg.storageHasCertResourcesAnyIssuer(name) {
 		return nil
 	}
@@ -486,6 +489,9 @@ func (cfg *Config) storageHasCertResourcesAnyIssuer(name string) bool {
 // renewed certificate and its assets in storage if successful. It
 // DOES NOT update the in-memory cache with the new certificate.
 func (cfg *Config) RenewCert(ctx context.Context, name string, interactive bool) error {
+	if len(cfg.Issuers) == 0 {
+		return fmt.Errorf("no issuers configured; impossible to renew or check existing certificate in storage")
+	}
 	// ensure storage is writeable and readable
 	// TODO: this is not necessary every time; should only perform check once every so often for each storage, which may require some global state...
 	err := cfg.checkStorage()

--- a/config_test.go
+++ b/config_test.go
@@ -25,7 +25,7 @@ import (
 func TestSaveCertResource(t *testing.T) {
 	am := &ACMEManager{CA: "https://example.com/acme/directory"}
 	testConfig := &Config{
-		Issuer:    am,
+		Issuers:   []Issuer{am},
 		Storage:   &FileStorage{Path: "./_testdata_tmp"},
 		certCache: new(Cache),
 	}
@@ -52,7 +52,7 @@ func TestSaveCertResource(t *testing.T) {
 		},
 	}
 
-	err := testConfig.saveCertResource(cert)
+	err := testConfig.saveCertResource(am, cert)
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestSaveCertResource(t *testing.T) {
 		"url": "https://example.com/cert",
 	}
 
-	siteData, err := testConfig.loadCertResource(domain)
+	siteData, err := testConfig.loadCertResource(am, domain)
 	if err != nil {
 		t.Fatalf("Expected no error reading site, got: %v", err)
 	}

--- a/crypto.go
+++ b/crypto.go
@@ -28,6 +28,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"strings"
 
 	"github.com/klauspost/cpuid"
@@ -129,13 +130,13 @@ func fastHash(input []byte) string {
 // saveCertResource saves the certificate resource to disk. This
 // includes the certificate file itself, the private key, and the
 // metadata file.
-func (cfg *Config) saveCertResource(cert CertificateResource) error {
+func (cfg *Config) saveCertResource(issuer Issuer, cert CertificateResource) error {
 	metaBytes, err := json.MarshalIndent(cert, "", "\t")
 	if err != nil {
 		return fmt.Errorf("encoding certificate metadata: %v", err)
 	}
 
-	issuerKey := cfg.Issuer.IssuerKey()
+	issuerKey := issuer.IssuerKey()
 	certKey := cert.NamesKey()
 
 	all := []keyValue{
@@ -156,9 +157,68 @@ func (cfg *Config) saveCertResource(cert CertificateResource) error {
 	return storeTx(cfg.Storage, all)
 }
 
-func (cfg *Config) loadCertResource(certNamesKey string) (CertificateResource, error) {
+// loadCertResourceAnyIssuer loads and returns the certificate resource from any
+// of the configured issuers. If multiple are found (e.g. if there are 3 issuers
+// configured, and all 3 have a resource matching certNamesKey), then the newest
+// (latest NotBefore date) resource will be chosen.
+func (cfg *Config) loadCertResourceAnyIssuer(certNamesKey string) (CertificateResource, error) {
+	// we can save some extra decoding steps if there's only one issuer, since
+	// we don't need to compare potentially multiple available resources to
+	// select the best one, when there's only one choice anyway
+	if len(cfg.Issuers) == 1 {
+		return cfg.loadCertResource(cfg.Issuers[0], certNamesKey)
+	}
+
+	type decodedCertResource struct {
+		CertificateResource
+		decoded *x509.Certificate
+	}
+	var certResources []decodedCertResource
+	var lastErr error
+
+	// load and decode all certificate resources found with the
+	// configured issuers so we can sort by newest
+	for _, issuer := range cfg.Issuers {
+		certRes, err := cfg.loadCertResource(issuer, certNamesKey)
+		if err != nil {
+			if _, ok := err.(ErrNotExist); ok {
+				// not a problem, but we need to remember the error
+				// in case we end up not finding any cert resources
+				// since we'll need an error to return in that case
+				lastErr = err
+				continue
+			}
+			return CertificateResource{}, err
+		}
+		certs, err := parseCertsFromPEMBundle(certRes.CertificatePEM)
+		if err != nil {
+			return CertificateResource{}, err
+		}
+		certResources = append(certResources, decodedCertResource{
+			CertificateResource: certRes,
+			decoded:             certs[0],
+		})
+	}
+	if len(certResources) == 0 {
+		if lastErr == nil {
+			lastErr = fmt.Errorf("no certificate resources found") // just in case; e.g. no Issuers configured
+		}
+		return CertificateResource{}, lastErr
+	}
+
+	// sort by date so the most recently issued comes first
+	sort.Slice(certResources, func(i, j int) bool {
+		return certResources[j].decoded.NotBefore.Before(certResources[i].decoded.NotBefore)
+	})
+
+	return certResources[0].CertificateResource, nil
+}
+
+// loadCertResource loads a certificate resource from the given issuer's storage location.
+func (cfg *Config) loadCertResource(issuer Issuer, certNamesKey string) (CertificateResource, error) {
 	var certRes CertificateResource
-	issuerKey := cfg.Issuer.IssuerKey()
+	issuerKey := issuer.IssuerKey()
+
 	certBytes, err := cfg.Storage.Load(StorageKeys.SiteCert(issuerKey, certNamesKey))
 	if err != nil {
 		return CertificateResource{}, err
@@ -180,7 +240,7 @@ func (cfg *Config) loadCertResource(certNamesKey string) (CertificateResource, e
 
 	// TODO: July 2020 - transition to new ACME lib and cert resource structure;
 	// for a while, we will need to convert old cert resources to new structure
-	certRes, err = cfg.transitionCertMetaToACMEzJuly2020Format(certRes, metaBytes)
+	certRes, err = cfg.transitionCertMetaToACMEzJuly2020Format(issuer, certRes, metaBytes)
 	if err != nil {
 		return certRes, fmt.Errorf("one-time certificate resource transition: %v", err)
 	}
@@ -190,7 +250,7 @@ func (cfg *Config) loadCertResource(certNamesKey string) (CertificateResource, e
 
 // TODO: this is a temporary transition helper starting July 2020.
 // It can go away when we think enough time has passed that most active assets have transitioned.
-func (cfg *Config) transitionCertMetaToACMEzJuly2020Format(certRes CertificateResource, metaBytes []byte) (CertificateResource, error) {
+func (cfg *Config) transitionCertMetaToACMEzJuly2020Format(issuer Issuer, certRes CertificateResource, metaBytes []byte) (CertificateResource, error) {
 	data, ok := certRes.IssuerData.(map[string]interface{})
 	if !ok {
 		return certRes, nil
@@ -217,7 +277,7 @@ func (cfg *Config) transitionCertMetaToACMEzJuly2020Format(certRes CertificateRe
 	}
 	certRes.IssuerData = data
 
-	err = cfg.saveCertResource(certRes)
+	err = cfg.saveCertResource(issuer, certRes)
 	if err != nil {
 		return certRes, fmt.Errorf("saving converted certificate resource: %v", err)
 	}

--- a/handshake.go
+++ b/handshake.go
@@ -260,7 +260,12 @@ func (cfg *Config) getCertDuringHandshake(hello *tls.ClientHelloInfo, loadIfNece
 	if cfg.OnDemand != nil && loadIfNecessary {
 		// Then check to see if we have one on disk
 		loadedCert, err := cfg.CacheManagedCertificate(name)
-		// TODO: try wildcard names too
+		if _, ok := err.(ErrNotExist); ok {
+			// If no exact match, try a wildcard variant, which is something we can still use
+			labels := strings.Split(name, ".")
+			labels[0] = "*"
+			loadedCert, err = cfg.CacheManagedCertificate(strings.Join(labels, "."))
+		}
 		if err == nil {
 			loadedCert, err = cfg.handshakeMaintenance(hello, loadedCert)
 			if err != nil {

--- a/httphandler.go
+++ b/httphandler.go
@@ -74,7 +74,11 @@ func (am *ACMEManager) distributedHTTPChallengeSolver(w http.ResponseWriter, r *
 
 	host := hostOnly(r.Host)
 
-	tokenKey := distributedSolver{acmeManager: am, caURL: am.CA}.challengeTokensKey(host)
+	tokenKey := distributedSolver{
+		storage:                am.config.Storage,
+		storageKeyIssuerPrefix: am.storageKeyCAPrefix(am.CA),
+	}.challengeTokensKey(host)
+
 	chalInfoBytes, err := am.config.Storage.Load(tokenKey)
 	if err != nil {
 		if _, ok := err.(ErrNotExist); !ok {

--- a/httphandler_test.go
+++ b/httphandler_test.go
@@ -24,7 +24,7 @@ import (
 func TestHTTPChallengeHandlerNoOp(t *testing.T) {
 	am := &ACMEManager{CA: "https://example.com/acme/directory"}
 	testConfig := &Config{
-		Issuer:    am,
+		Issuers:   []Issuer{am},
 		Storage:   &FileStorage{Path: "./_testdata_tmp"},
 		certCache: new(Cache),
 	}


### PR DESCRIPTION
This change refactors Config.Issuer to be Config.Issuers, an array of
issuers. Each Issuer will be tried in turn until one succeeds. During
retries, each attempt will try each configured Issuer. When loading
certs from storage, CertMagic will look in each Issuer's storage
location for a qualifying asset. If multiple Issuers have one in storage
then the most-recently-issued cert will be selected.

This is a breaking change in that Config now accepts a slice of Issuers
rather than a single Issuer. The Revoker field is removed, as supporting
it is optional anyway. If the Issuer is also a Revoker, it can be used
implicitly to revoke certificates.

Also added a const for ZeroSSL's ACME endpoint.

Also, bug fixes for distributed solving of TLS-ALPN challenge:

The type assertion in handshake.go was problematic since there's no
guarantee that an ACME issuer would be a concrete ACMEManager type.

Refactored the code to accept IssuerKey values generally, rather than
specific ACMEManager values only.

This fixes solving tls-alpn challenges in distributed settings.

More cleanup can be done, another time.