### PR TITLE
fix dns solver example code to compile okay

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ To enable it, just set the `DNS01Solver` field on a `certmagic.ACMEManager` stru
 import "github.com/libdns/cloudflare"
 
 certmagic.DefaultACME.DNS01Solver = &certmagic.DNS01Solver{
-	DNSProvider: cloudflare.Provider{
+	DNSProvider: &cloudflare.Provider{
 		APIToken: "topsecret",
 	},
 }


### PR DESCRIPTION
As reported in #113, the example code for implementing a DNS provider does not compile,
and in my opinion results in a cryptic message. (maybe everybody else figures it out? )

Nonetheless, I thought this fix would be a nice contribution to help others avoid having to try to figure out
that message.