### PR TITLE
Prioritize the configured resolvers

### DIFF
--- a/dnsutil.go
+++ b/dnsutil.go
@@ -325,7 +325,6 @@ func recursiveNameservers(custom []string) []string {
 		copy(servers, custom)
 	}
 	populateNameserverPorts(servers)
-	fmt.Printf("populated servers, ignoring resolve.conf: %v", servers)
 	return servers
 }
 

--- a/dnsutil.go
+++ b/dnsutil.go
@@ -317,13 +317,15 @@ func updateDomainWithCName(r *dns.Msg, fqdn string) string {
 // the records and the bool result is set to true
 func isImportant(custom []string) ([]string, bool) {
 	important := false
-	list := make([]string, len(custom))
-	for i, v := range custom {
+	list := []string{}
+	for _, v := range custom {
 		if strings.HasSuffix(v, "!important") {
 			important = true
-			list[i] = strings.TrimSuffix(v, "!important")
+			if v = strings.TrimSuffix(v, "!important"); v != "" {
+				list = append(list, v)
+			}
 		} else {
-			list[i] = v
+			list = append(list, v)
 		}
 	}
 	return list, important

--- a/dnsutil_test.go
+++ b/dnsutil_test.go
@@ -237,14 +237,17 @@ func TestRecursiveNameserversAddsPort(t *testing.T) {
 		t.Errorf("%v Expected custom resolvers to be included, but they weren't: %v", results, custom)
 	}
 
-	results = recursiveNameservers([]string{})
-	if len(results) < 4 {
-		t.Errorf("%v Expected at least 4 records as default when empty custom", results)
+}
+
+func TestRecursiveNameserversDefaults(t *testing.T) {
+	results := recursiveNameservers(nil)
+	if len(results) < 1 {
+		t.Errorf("%v Expected at least 1 records as default when nil custom", results)
 	}
 
-	results = recursiveNameservers(nil)
-	if len(results) < 4 {
-		t.Errorf("%v Expected at least 4 records as default when nil custom", results)
+	results = recursiveNameservers([]string{})
+	if len(results) < 1 {
+		t.Errorf("%v Expected at least 1 records as default when empty custom", results)
 	}
 }
 


### PR DESCRIPTION
Make configured resolvers important and do not allow any fallback or other ones being used.
This solves some issues when for example using a split-head DNS and certmagic falls back to using /etc/resolve.conf.
It forces the use of only the configured resolvers and nothing else.

__ Caddyfile__
```
resolvers ns1.loopia.se !important
# or
resolvers ns1.loopia.se!important
```

__JSON__ 
```json
"resolvers": [
    "ns1.loopia.se",
    "!important"
  ]
```
alternatively
```json
"resolvers": [
    "ns1.loopia.se!important"
  ]
```