### PR TITLE
Add checks if log is nil

### DIFF
--- a/config.go
+++ b/config.go
@@ -508,8 +508,10 @@ func (cfg *Config) obtainCert(ctx context.Context, name string, interactive bool
 		var issuedCert *IssuedCertificate
 		var issuerUsed Issuer
 		for i, issuer := range issuers {
-			log.Debug(fmt.Sprintf("trying issuer %d/%d", i+1, len(cfg.Issuers)),
-				zap.String("issuer", issuer.IssuerKey()))
+			if log != nil {
+				log.Debug(fmt.Sprintf("trying issuer %d/%d", i+1, len(cfg.Issuers)),
+					zap.String("issuer", issuer.IssuerKey()))
+			}
 
 			if prechecker, ok := issuer.(PreChecker); ok {
 				err = prechecker.PreCheck(ctx, []string{name}, interactive)
@@ -531,10 +533,12 @@ func (cfg *Config) obtainCert(ctx context.Context, name string, interactive bool
 			if errors.As(err, &problem) {
 				errToLog = problem
 			}
-			log.Error("could not get certificate from issuer",
-				zap.String("identifier", name),
-				zap.String("issuer", issuer.IssuerKey()),
-				zap.Error(errToLog))
+			if log != nil {
+				log.Error("could not get certificate from issuer",
+					zap.String("identifier", name),
+					zap.String("issuer", issuer.IssuerKey()),
+					zap.Error(errToLog))
+			}
 		}
 		if err != nil {
 			// only the error from the last issuer will be returned, but we logged the others
@@ -745,10 +749,12 @@ func (cfg *Config) renewCert(ctx context.Context, name string, force, interactiv
 			if errors.As(err, &problem) {
 				errToLog = problem
 			}
-			log.Error("could not get certificate from issuer",
-				zap.String("identifier", name),
-				zap.String("issuer", issuer.IssuerKey()),
-				zap.Error(errToLog))
+			if log != nil {
+				log.Error("could not get certificate from issuer",
+					zap.String("identifier", name),
+					zap.String("issuer", issuer.IssuerKey()),
+					zap.Error(errToLog))
+			}
 		}
 		if err != nil {
 			// only the error from the last issuer will be returned, but we logged the others


### PR DESCRIPTION
Commit 388f3ed introduced new log statements that were not guarded by the typical `if log != nil {...` pattern seen elsewhere in the codebase. This resulted in a segfault at runtime:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x81cbe7]

goroutine 1 [running]:
go.uber.org/zap.(*Logger).check(0x0, 0xff, 0xc0002f0d98, 0x11, 0xc00021ce80)
	/Users/ryan/Projects/go/pkg/mod/go.uber.org/zap@v1.17.0/logger.go:265 +0x987
go.uber.org/zap.(*Logger).Debug(0x0, 0xc0002f0d98, 0x11, 0xc00021ce80, 0x1, 0x1)
	/Users/ryan/Projects/go/pkg/mod/go.uber.org/zap@v1.17.0/logger.go:180 +0x45
github.com/caddyserver/certmagic.(*Config).obtainCert.func2(0xd8ad08, 0xc000034070, 0xd91650, 0x11d4b80)
	/Users/ryan/Projects/go/pkg/mod/github.com/caddyserver/certmagic@v0.14.0/config.go:511 +0x5c5
github.com/caddyserver/certmagic.(*Config).obtainCert(0xc0001ef540, 0xd8ad08, 0xc000034070, 0x7ffea6f646c6, 0x14, 0x1, 0x0, 0x0)
	/Users/ryan/Projects/go/pkg/mod/github.com/caddyserver/certmagic@v0.14.0/config.go:566 +0x3a8
```

This PR adds those checks to prevent such crashes.