### PR TITLE
Provide more detailed information in certificate events

### DIFF
--- a/config.go
+++ b/config.go
@@ -1107,6 +1107,7 @@ type OCSPConfig struct {
 
 // CertificateEventData contains contextual information for
 // an obtained, renewed or revoked certificate.
+// EXPERIMENTAL: subject to change.
 type CertificateEventData struct {
 	// Domain or subject name of the certificate.
 	Name string

--- a/config.go
+++ b/config.go
@@ -573,10 +573,10 @@ func (cfg *Config) obtainCert(ctx context.Context, name string, interactive bool
 			return fmt.Errorf("[%s] Obtain: saving assets: %v", name, err)
 		}
 
-		cfg.emit("cert_obtained", CertEventData{
-			Name:      name,
-			IssuerKey: issuerUsed.IssuerKey(),
-			CertKey:   certRes.NamesKey(),
+		cfg.emit("cert_obtained", CertificateEventData{
+			Name:       name,
+			IssuerKey:  issuerUsed.IssuerKey(),
+			StorageKey: certRes.NamesKey(),
 		})
 
 		if log != nil {
@@ -793,10 +793,10 @@ func (cfg *Config) renewCert(ctx context.Context, name string, force, interactiv
 			return fmt.Errorf("[%s] Renew: saving assets: %v", name, err)
 		}
 
-		cfg.emit("cert_renewed", CertEventData{
-			Name:      name,
-			IssuerKey: issuerUsed.IssuerKey(),
-			CertKey:   certRes.NamesKey(),
+		cfg.emit("cert_renewed", CertificateEventData{
+			Name:       name,
+			IssuerKey:  issuerUsed.IssuerKey(),
+			StorageKey: certRes.NamesKey(),
 		})
 
 		if log != nil {
@@ -876,10 +876,10 @@ func (cfg *Config) RevokeCert(ctx context.Context, domain string, reason int, in
 			return fmt.Errorf("issuer %d (%s): %v", i, issuerKey, err)
 		}
 
-		cfg.emit("cert_revoked", CertEventData{
-			Name:      domain,
-			IssuerKey: issuerKey,
-			CertKey:   certRes.NamesKey(),
+		cfg.emit("cert_revoked", CertificateEventData{
+			Name:       domain,
+			IssuerKey:  issuerKey,
+			StorageKey: certRes.NamesKey(),
 		})
 
 		err = cfg.deleteSiteAssets(ctx, issuerKey, domain)
@@ -1105,17 +1105,17 @@ type OCSPConfig struct {
 	ResponderOverrides map[string]string
 }
 
-// CertEventData contains contextual information for
+// CertificateEventData contains contextual information for
 // an obtained, renewed or revoked certificate.
-type CertEventData struct {
+type CertificateEventData struct {
 	// Domain or subject name of the certificate.
 	Name string
 
 	// Storage key for the issuer used for this certificate.
 	IssuerKey string
 
-	// Storage key for the certificate by its name.
-	CertKey string
+	// Location in storage at which the certificate could be found.
+	StorageKey string
 }
 
 // certIssueLockOp is the name of the operation used

--- a/config.go
+++ b/config.go
@@ -573,7 +573,11 @@ func (cfg *Config) obtainCert(ctx context.Context, name string, interactive bool
 			return fmt.Errorf("[%s] Obtain: saving assets: %v", name, err)
 		}
 
-		cfg.emit("cert_obtained", name)
+		cfg.emit("cert_obtained", CertEventData{
+			Name:      name,
+			IssuerKey: issuerUsed.IssuerKey(),
+			CertKey:   certRes.NamesKey(),
+		})
 
 		if log != nil {
 			log.Info("certificate obtained successfully", zap.String("identifier", name))
@@ -789,7 +793,11 @@ func (cfg *Config) renewCert(ctx context.Context, name string, force, interactiv
 			return fmt.Errorf("[%s] Renew: saving assets: %v", name, err)
 		}
 
-		cfg.emit("cert_renewed", name)
+		cfg.emit("cert_renewed", CertEventData{
+			Name:      name,
+			IssuerKey: issuerUsed.IssuerKey(),
+			CertKey:   certRes.NamesKey(),
+		})
 
 		if log != nil {
 			log.Info("certificate renewed successfully", zap.String("identifier", name))
@@ -868,7 +876,11 @@ func (cfg *Config) RevokeCert(ctx context.Context, domain string, reason int, in
 			return fmt.Errorf("issuer %d (%s): %v", i, issuerKey, err)
 		}
 
-		cfg.emit("cert_revoked", domain)
+		cfg.emit("cert_revoked", CertEventData{
+			Name:      domain,
+			IssuerKey: issuerKey,
+			CertKey:   certRes.NamesKey(),
+		})
 
 		err = cfg.deleteSiteAssets(ctx, issuerKey, domain)
 		if err != nil {
@@ -1091,6 +1103,19 @@ type OCSPConfig struct {
 	// embedded in certificates. Mapping to an empty
 	// URL will disable OCSP from that responder.
 	ResponderOverrides map[string]string
+}
+
+// CertEventData contains contextual information for
+// an obtained, renewed or revoked certificate.
+type CertEventData struct {
+	// Domain or subject name of the certificate.
+	Name string
+
+	// Storage key for the issuer used for this certificate.
+	IssuerKey string
+
+	// Storage key for the certificate by its name.
+	CertKey string
 }
 
 // certIssueLockOp is the name of the operation used


### PR DESCRIPTION
The `cert_*` events were only providing the domain. This was pretty limited, because not much can be done with it without also knowing the issuer, since that affects where the cert is stored.

Providing both the `issuerKey` and `certKey` makes it possible for the event listener to call `StorageKeys.SiteCert(issuerKey, certKey)` to get the actual location of the cert (and similarly the private key). Particularly useful in situations where the user wants to copy the cert/key to some location for another app to use the cert that is being managed.

A similar change could probably also be done for `cached_managed_cert` and `cached_unmanaged_cert` events to provide more detail, because `cert.Names` string slice doesn't seem that useful, can't do much with that alone. But I'm not sure I understand the usefulness of those events, so meh. Caching seems like pretty much an internal implementation detail of certmagic.

Note: This is a breaking change for any users of certmagic that use `OnEvent`, but only because we've wrapped the existing information with a new type, to provide _more_ information. Shouldn't harm anyone.