### PR TITLE
duplicate OnDemand default value assign check

### DIFF
--- a/config.go
+++ b/config.go
@@ -197,9 +197,6 @@ func newWithCache(certCache *Cache, cfg Config) *Config {
 	if cfg.DefaultServerName == "" {
 		cfg.DefaultServerName = Default.DefaultServerName
 	}
-	if cfg.OnDemand == nil {
-		cfg.OnDemand = Default.OnDemand
-	}
 	if !cfg.MustStaple {
 		cfg.MustStaple = Default.MustStaple
 	}


### PR DESCRIPTION
The `newWithCache` func inside `config.go` has duplicate check and assign statement for `cfg.OnDemand`.