### PR TITLE
Support OverrideDomain is DNS01Solver

### DIFF
--- a/dnsutil.go
+++ b/dnsutil.go
@@ -214,10 +214,20 @@ func checkDNSPropagation(fqdn, value string, resolvers []string) (bool, error) {
 		fqdn += "."
 	}
 
+	// Initial attempt to resolve at the recursive NS
+	r, err := dnsQuery(fqdn, dns.TypeTXT, resolvers, true)
+	if err != nil {
+		return false, err
+	}
+
 	// TODO: make this configurable, maybe
 	// if !p.requireCompletePropagation {
 	// 	return true, nil
 	// }
+
+	if r.Rcode == dns.RcodeSuccess {
+		fqdn = updateDomainWithCName(r, fqdn)
+	}
 
 	authoritativeNss, err := lookupNameservers(fqdn, resolvers)
 	if err != nil {

--- a/dnsutil.go
+++ b/dnsutil.go
@@ -214,20 +214,10 @@ func checkDNSPropagation(fqdn, value string, resolvers []string) (bool, error) {
 		fqdn += "."
 	}
 
-	// Initial attempt to resolve at the recursive NS
-	r, err := dnsQuery(fqdn, dns.TypeTXT, resolvers, true)
-	if err != nil {
-		return false, err
-	}
-
 	// TODO: make this configurable, maybe
 	// if !p.requireCompletePropagation {
 	// 	return true, nil
 	// }
-
-	if r.Rcode == dns.RcodeSuccess {
-		fqdn = updateDomainWithCName(r, fqdn)
-	}
 
 	authoritativeNss, err := lookupNameservers(fqdn, resolvers)
 	if err != nil {

--- a/solvers.go
+++ b/solvers.go
@@ -252,6 +252,11 @@ type DNS01Solver struct {
 	// Preferred DNS resolver(s) to use when doing DNS lookups.
 	Resolvers []string
 
+	// Override the domain to set the TXT record on. This is
+	// to delegate the chanllenge to a different domain. Note
+	// that the solver doesn't follow CNAME/NS record.
+	OverrideDomain string
+
 	txtRecords   map[string]dnsPresentMemory // keyed by domain name
 	txtRecordsMu sync.Mutex
 }
@@ -259,6 +264,9 @@ type DNS01Solver struct {
 // Present creates the DNS TXT record for the given ACME challenge.
 func (s *DNS01Solver) Present(ctx context.Context, challenge acme.Challenge) error {
 	dnsName := challenge.DNS01TXTRecordName()
+	if s.OverrideDomain != "" {
+		dnsName = s.OverrideDomain
+	}
 	keyAuth := challenge.DNS01KeyAuthorization()
 
 	// multiple identifiers can have the same ACME challenge
@@ -304,6 +312,9 @@ func (s *DNS01Solver) Present(ctx context.Context, challenge acme.Challenge) err
 // timeout, whichever is first.
 func (s *DNS01Solver) Wait(ctx context.Context, challenge acme.Challenge) error {
 	dnsName := challenge.DNS01TXTRecordName()
+	if s.OverrideDomain != "" {
+		dnsName = s.OverrideDomain
+	}
 	keyAuth := challenge.DNS01KeyAuthorization()
 
 	timeout := s.PropagationTimeout

--- a/solvers.go
+++ b/solvers.go
@@ -334,7 +334,11 @@ func (s *DNS01Solver) Wait(ctx context.Context, challenge acme.Challenge) error 
 			return ctx.Err()
 		}
 		var ready bool
-		ready, err = checkDNSPropagation(dnsName, keyAuth, resolvers)
+		if s.OverrideDomain == "" {
+			ready, err = checkDNSPropagation(dnsName, keyAuth, resolvers)
+		} else {
+			ready, err = checkAuthoritativeNss(dnsName, keyAuth, resolvers)
+		}
 		if err != nil {
 			return fmt.Errorf("checking DNS propagation of %s: %w", dnsName, err)
 		}

--- a/solvers.go
+++ b/solvers.go
@@ -253,7 +253,7 @@ type DNS01Solver struct {
 	Resolvers []string
 
 	// Override the domain to set the TXT record on. This is
-	// to delegate the chanllenge to a different domain. Note
+	// to delegate the challenge to a different domain. Note
 	// that the solver doesn't follow CNAME/NS record.
 	OverrideDomain string
 


### PR DESCRIPTION
CNAME can be used to delegate answering the chanllenge to another DNS
zone, in order to reduce the exposure of the DNS credential [1]. The
solver already follows CNAME when checking propagation against the
authoritative source, it should follow CNAME when setting the TXT record
as well.

[1] https://letsencrypt.org/docs/challenge-types/#dns-01-challenge