### PR TITLE
Managers: Ability to call GetCertificate from external certificate sources

### DIFF
--- a/account.go
+++ b/account.go
@@ -62,7 +62,7 @@ func (am *ACMEManager) loadAccount(ca, email string) (acme.Account, error) {
 	if err != nil {
 		return acct, err
 	}
-	acct.PrivateKey, err = decodePrivateKey(keyBytes)
+	acct.PrivateKey, err = PEMDecodePrivateKey(keyBytes)
 	if err != nil {
 		return acct, fmt.Errorf("could not decode account's private key: %v", err)
 	}
@@ -129,7 +129,7 @@ func (am *ACMEManager) lookUpAccount(ctx context.Context, privateKeyPEM []byte) 
 		return acme.Account{}, fmt.Errorf("creating ACME client: %v", err)
 	}
 
-	privateKey, err := decodePrivateKey([]byte(privateKeyPEM))
+	privateKey, err := PEMDecodePrivateKey([]byte(privateKeyPEM))
 	if err != nil {
 		return acme.Account{}, fmt.Errorf("decoding private key: %v", err)
 	}
@@ -157,7 +157,7 @@ func (am *ACMEManager) saveAccount(ca string, account acme.Account) error {
 	if err != nil {
 		return err
 	}
-	keyBytes, err := encodePrivateKey(account.PrivateKey)
+	keyBytes, err := PEMEncodePrivateKey(account.PrivateKey)
 	if err != nil {
 		return err
 	}

--- a/certificates.go
+++ b/certificates.go
@@ -54,6 +54,12 @@ type Certificate struct {
 	issuerKey string
 }
 
+// Empty returns true if the certificate struct is not filled out; at
+// least the tls.Certificate.Certificate field is expected to be set.
+func (cert Certificate) Empty() bool {
+	return len(cert.Certificate.Certificate) == 0
+}
+
 // NeedsRenewal returns true if the certificate is
 // expiring soon (according to cfg) or has expired.
 func (cert Certificate) NeedsRenewal(cfg *Config) bool {

--- a/certificates.go
+++ b/certificates.go
@@ -257,11 +257,15 @@ func fillCertFromLeaf(cert *Certificate, tlsCert tls.Certificate) error {
 	// the leaf cert should be the one for the site; we must set
 	// the tls.Certificate.Leaf field so that TLS handshakes are
 	// more efficient
-	leaf, err := x509.ParseCertificate(tlsCert.Certificate[0])
-	if err != nil {
-		return err
+	leaf := cert.Certificate.Leaf
+	if leaf == nil {
+		var err error
+		leaf, err = x509.ParseCertificate(tlsCert.Certificate[0])
+		if err != nil {
+			return err
+		}
+		cert.Certificate.Leaf = leaf
 	}
-	cert.Certificate.Leaf = leaf
 
 	// for convenience, we do want to assemble all the
 	// subjects on the certificate into one list

--- a/certificates.go
+++ b/certificates.go
@@ -396,9 +396,10 @@ func SubjectIsInternal(subj string) bool {
 // states that IP addresses must match exactly, but this function
 // does not attempt to distinguish IP addresses from internal or
 // external DNS names that happen to look like IP addresses.
-// It uses DNS wildcard matching logic.
+// It uses DNS wildcard matching logic and is case-insensitive.
 // https://tools.ietf.org/html/rfc2818#section-3.1
 func MatchWildcard(subject, wildcard string) bool {
+	subject, wildcard = strings.ToLower(subject), strings.ToLower(wildcard)
 	if subject == wildcard {
 		return true
 	}

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -190,10 +190,14 @@ func TestMatchWildcard(t *testing.T) {
 		expect            bool
 	}{
 		{"hostname", "hostname", true},
+		{"HOSTNAME", "hostname", true},
+		{"hostname", "HOSTNAME", true},
 		{"foo.localhost", "foo.localhost", true},
 		{"foo.localhost", "bar.localhost", false},
 		{"foo.localhost", "*.localhost", true},
 		{"bar.localhost", "*.localhost", true},
+		{"FOO.LocalHost", "*.localhost", true},
+		{"Bar.localhost", "*.LOCALHOST", true},
 		{"foo.bar.localhost", "*.localhost", false},
 		{".localhost", "*.localhost", false},
 		{"foo.localhost", "foo.*", false},

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -27,7 +27,7 @@ func TestUnexportedGetCertificate(t *testing.T) {
 	cfg := &Config{certCache: certCache}
 
 	// When cache is empty
-	if _, matched, defaulted := cfg.getCertificate(&tls.ClientHelloInfo{ServerName: "example.com"}); matched || defaulted {
+	if _, matched, defaulted := cfg.getCertificateFromCache(&tls.ClientHelloInfo{ServerName: "example.com"}); matched || defaulted {
 		t.Errorf("Got a certificate when cache was empty; matched=%v, defaulted=%v", matched, defaulted)
 	}
 
@@ -35,19 +35,19 @@ func TestUnexportedGetCertificate(t *testing.T) {
 	firstCert := Certificate{Names: []string{"example.com"}}
 	certCache.cache["0xdeadbeef"] = firstCert
 	certCache.cacheIndex["example.com"] = []string{"0xdeadbeef"}
-	if cert, matched, defaulted := cfg.getCertificate(&tls.ClientHelloInfo{ServerName: "example.com"}); !matched || defaulted || cert.Names[0] != "example.com" {
+	if cert, matched, defaulted := cfg.getCertificateFromCache(&tls.ClientHelloInfo{ServerName: "example.com"}); !matched || defaulted || cert.Names[0] != "example.com" {
 		t.Errorf("Didn't get a cert for 'example.com' or got the wrong one: %v, matched=%v, defaulted=%v", cert, matched, defaulted)
 	}
 
 	// When retrieving wildcard certificate
 	certCache.cache["0xb01dface"] = Certificate{Names: []string{"*.example.com"}}
 	certCache.cacheIndex["*.example.com"] = []string{"0xb01dface"}
-	if cert, matched, defaulted := cfg.getCertificate(&tls.ClientHelloInfo{ServerName: "sub.example.com"}); !matched || defaulted || cert.Names[0] != "*.example.com" {
+	if cert, matched, defaulted := cfg.getCertificateFromCache(&tls.ClientHelloInfo{ServerName: "sub.example.com"}); !matched || defaulted || cert.Names[0] != "*.example.com" {
 		t.Errorf("Didn't get wildcard cert for 'sub.example.com' or got the wrong one: %v, matched=%v, defaulted=%v", cert, matched, defaulted)
 	}
 
 	// When no certificate matches and SNI is provided, return no certificate (should be TLS alert)
-	if cert, matched, defaulted := cfg.getCertificate(&tls.ClientHelloInfo{ServerName: "nomatch"}); matched || defaulted {
+	if cert, matched, defaulted := cfg.getCertificateFromCache(&tls.ClientHelloInfo{ServerName: "nomatch"}); matched || defaulted {
 		t.Errorf("Expected matched=false, defaulted=false; but got matched=%v, defaulted=%v (cert: %v)", matched, defaulted, cert)
 	}
 }

--- a/certmagic.go
+++ b/certmagic.go
@@ -305,7 +305,7 @@ type CertificateGetter interface {
 	// expiration, or false if it should not be cached. It returns nil+false+nil
 	// if there is no certificate available (but no error to speak of, either),
 	// and normal certificate logic will continue.
-	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, bool, error)
+	GetCertificate(context.Context, *tls.ClientHelloInfo) (*tls.Certificate, bool, error)
 }
 
 func (o *OnDemandConfig) whitelistContains(name string) bool {

--- a/certmagic.go
+++ b/certmagic.go
@@ -262,6 +262,21 @@ type OnDemandConfig struct {
 	// request will be denied.
 	DecisionFunc func(name string) error
 
+	// CustomGetCertificate is an optional override for
+	// CertMagic's built-in GetCertificate for this
+	// config. If set, it will be called at every TLS
+	// handshake. If it returns a nil certificate and
+	// nil error, CertMagic's own GetCertificate will
+	// still continue as normal. Otherwise, the cert
+	// or error returned from this function will be used.
+	// If true is the middle return value, the certificate
+	// will be cached until close to expiration and reused
+	// until then; otherwise it will not be cached.
+	// Setting this field will not interrupt ACME TLS-ALPN
+	// challenge handshakes.
+	// TODO: EXPERIMENTAL: subject to change and/or removal.
+	CustomGetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, bool, error)
+
 	// List of whitelisted hostnames (SNI values) for
 	// deferred (on-demand) obtaining of certificates.
 	// Used only by higher-level functions in this

--- a/certmagic.go
+++ b/certmagic.go
@@ -275,7 +275,7 @@ type OnDemandConfig struct {
 	// Setting this field will not interrupt ACME TLS-ALPN
 	// challenge handshakes.
 	// TODO: EXPERIMENTAL: subject to change and/or removal.
-	CustomGetCertificate CertificateGetter
+	CustomGetCertificates []CertificateGetter
 
 	// List of whitelisted hostnames (SNI values) for
 	// deferred (on-demand) obtaining of certificates.

--- a/certmagic.go
+++ b/certmagic.go
@@ -275,7 +275,7 @@ type OnDemandConfig struct {
 	// Setting this field will not interrupt ACME TLS-ALPN
 	// challenge handshakes.
 	// TODO: EXPERIMENTAL: subject to change and/or removal.
-	CustomGetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, bool, error)
+	CustomGetCertificate CertificateGetter
 
 	// List of whitelisted hostnames (SNI values) for
 	// deferred (on-demand) obtaining of certificates.
@@ -294,6 +294,18 @@ type OnDemandConfig struct {
 	// have their run of any domain names they want.
 	// Only enforced if len > 0.
 	hostWhitelist []string
+}
+
+// CertificateGetter is a type that can get a certificate during
+// every TLS handshake (so it should be as fast as possible).
+// TODO: This is an EXPERIMENTAL API. It is subject to change/removal.
+type CertificateGetter interface {
+	// GetCertificate returns the certificate to use to complete the handshake,
+	// and true if CertMagic should cache and reuse the certificate until close to
+	// expiration, or false if it should not be cached. It returns nil+false+nil
+	// if there is no certificate available (but no error to speak of, either),
+	// and normal certificate logic will continue.
+	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, bool, error)
 }
 
 func (o *OnDemandConfig) whitelistContains(name string) bool {

--- a/config.go
+++ b/config.go
@@ -87,19 +87,6 @@ type Config struct {
 	// be used.
 	CertSelection CertificateSelector
 
-	// CustomGetCertificate is an optional override for
-	// CertMagic's built-in GetCertificate for this
-	// config. If set, it will be called at every TLS
-	// handshake. If it returns a nil certificate and
-	// nil error, CertMagic's own GetCertificate will
-	// still continue as normal. Otherwise, the cert
-	// or error returned from this function will be used.
-	// Certs returned from this function are not cached,
-	// so implementations must do their own caching.
-	// Setting this field will not interrupt ACME TLS-ALPN
-	// challenge handshakes.
-	CustomGetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
-
 	// OCSP configures how OCSP is handled. By default,
 	// OCSP responses are fetched for every certificate
 	// with a responder URL, and cached on disk. Changing

--- a/config.go
+++ b/config.go
@@ -72,11 +72,20 @@ type Config struct {
 	// Adds the must staple TLS extension to the CSR.
 	MustStaple bool
 
-	// The source for getting new certificates; the
-	// default Issuer is ACMEManager. If multiple
+	// Sources for getting new, managed certificates;
+	// the default Issuer is ACMEManager. If multiple
 	// issuers are specified, they will be tried in
 	// turn until one succeeds.
 	Issuers []Issuer
+
+	// Sources for getting new, unmanaged certificates.
+	// They will be invoked only during TLS handshakes
+	// before on-demand certificate management occurs,
+	// for certificates that are not already loaded into
+	// the in-memory cache.
+	//
+	// TODO: EXPERIMENTAL: subject to change and/or removal.
+	Managers []CertificateManager
 
 	// The source of new private keys for certificates;
 	// the default KeySource is StandardKeyGenerator.

--- a/config.go
+++ b/config.go
@@ -87,6 +87,19 @@ type Config struct {
 	// be used.
 	CertSelection CertificateSelector
 
+	// CustomGetCertificate is an optional override for
+	// CertMagic's built-in GetCertificate for this
+	// config. If set, it will be called at every TLS
+	// handshake. If it returns a nil certificate and
+	// nil error, CertMagic's own GetCertificate will
+	// still continue as normal. Otherwise, the cert
+	// or error returned from this function will be used.
+	// Certs returned from this function are not cached,
+	// so implementations must do their own caching.
+	// Setting this field will not interrupt ACME TLS-ALPN
+	// challenge handshakes.
+	CustomGetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
+
 	// OCSP configures how OCSP is handled. By default,
 	// OCSP responses are fetched for every certificate
 	// with a responder URL, and cached on disk. Changing

--- a/config.go
+++ b/config.go
@@ -490,7 +490,7 @@ func (cfg *Config) obtainCert(ctx context.Context, name string, interactive bool
 			if err != nil {
 				return err
 			}
-			privKeyPEM, err = encodePrivateKey(privKey)
+			privKeyPEM, err = PEMEncodePrivateKey(privKey)
 			if err != nil {
 				return err
 			}
@@ -596,7 +596,7 @@ func (cfg *Config) reusePrivateKey(domain string) (privKey crypto.PrivateKey, pr
 		}
 
 		// we loaded a private key; try decoding it so we can use it
-		privKey, err = decodePrivateKey(privKeyPEM)
+		privKey, err = PEMDecodePrivateKey(privKeyPEM)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -713,7 +713,7 @@ func (cfg *Config) renewCert(ctx context.Context, name string, force, interactiv
 				zap.Duration("remaining", timeLeft))
 		}
 
-		privateKey, err := decodePrivateKey(certRes.PrivateKeyPEM)
+		privateKey, err := PEMDecodePrivateKey(certRes.PrivateKeyPEM)
 		if err != nil {
 			return err
 		}

--- a/crypto.go
+++ b/crypto.go
@@ -36,8 +36,10 @@ import (
 	"golang.org/x/net/idna"
 )
 
-// encodePrivateKey marshals a EC or RSA private key into a PEM-encoded array of bytes.
-func encodePrivateKey(key crypto.PrivateKey) ([]byte, error) {
+// PEMEncodePrivateKey marshals a private key into a PEM-encoded block.
+// The private key must be one of *ecdsa.PrivateKey, *rsa.PrivateKey, or
+// *ed25519.PrivateKey.
+func PEMEncodePrivateKey(key crypto.PrivateKey) ([]byte, error) {
 	var pemType string
 	var keyBytes []byte
 	switch key := key.(type) {
@@ -65,11 +67,13 @@ func encodePrivateKey(key crypto.PrivateKey) ([]byte, error) {
 	return pem.EncodeToMemory(&pemKey), nil
 }
 
-// decodePrivateKey loads a PEM-encoded ECC/RSA private key from an array of bytes.
+// PEMDecodePrivateKey loads a PEM-encoded ECC/RSA private key from an array of bytes.
 // Borrowed from Go standard library, to handle various private key and PEM block types.
-// https://github.com/golang/go/blob/693748e9fa385f1e2c3b91ca9acbb6c0ad2d133d/src/crypto/tls/tls.go#L291-L308
-// https://github.com/golang/go/blob/693748e9fa385f1e2c3b91ca9acbb6c0ad2d133d/src/crypto/tls/tls.go#L238)
-func decodePrivateKey(keyPEMBytes []byte) (crypto.Signer, error) {
+func PEMDecodePrivateKey(keyPEMBytes []byte) (crypto.Signer, error) {
+	// Modified from original:
+	// https://github.com/golang/go/blob/693748e9fa385f1e2c3b91ca9acbb6c0ad2d133d/src/crypto/tls/tls.go#L291-L308
+	// https://github.com/golang/go/blob/693748e9fa385f1e2c3b91ca9acbb6c0ad2d133d/src/crypto/tls/tls.go#L238
+
 	keyBlockDER, _ := pem.Decode(keyPEMBytes)
 
 	if keyBlockDER == nil {

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -33,19 +33,19 @@ func TestEncodeDecodeRSAPrivateKey(t *testing.T) {
 	}
 
 	// test save
-	savedBytes, err := encodePrivateKey(privateKey)
+	savedBytes, err := PEMEncodePrivateKey(privateKey)
 	if err != nil {
 		t.Fatal("error saving private key:", err)
 	}
 
 	// test load
-	loadedKey, err := decodePrivateKey(savedBytes)
+	loadedKey, err := PEMDecodePrivateKey(savedBytes)
 	if err != nil {
 		t.Error("error loading private key:", err)
 	}
 
 	// test load (should fail)
-	_, err = decodePrivateKey(savedBytes[2:])
+	_, err = PEMDecodePrivateKey(savedBytes[2:])
 	if err == nil {
 		t.Error("loading private key should have failed")
 	}
@@ -63,13 +63,13 @@ func TestSaveAndLoadECCPrivateKey(t *testing.T) {
 	}
 
 	// test save
-	savedBytes, err := encodePrivateKey(privateKey)
+	savedBytes, err := PEMEncodePrivateKey(privateKey)
 	if err != nil {
 		t.Fatal("error saving private key:", err)
 	}
 
 	// test load
-	loadedKey, err := decodePrivateKey(savedBytes)
+	loadedKey, err := PEMDecodePrivateKey(savedBytes)
 	if err != nil {
 		t.Error("error loading private key:", err)
 	}

--- a/handshake.go
+++ b/handshake.go
@@ -650,7 +650,7 @@ func (cfg *Config) renewDynamicCertificate(hello *tls.ClientHelloInfo, currentCe
 // It turns the result (if any) into a filled-in Certificate value, and adds it to the cache if
 // applicable (replacing oldCert, if non-empty).
 func (cfg *Config) getCertFromCustomGetCertificate(hello *tls.ClientHelloInfo, log *zap.Logger, oldCert Certificate) (Certificate, error) {
-	upstreamCert, addToCache, err := cfg.OnDemand.CustomGetCertificate.GetCertificate(hello)
+	upstreamCert, addToCache, err := cfg.OnDemand.CustomGetCertificate.GetCertificate(context.Background(), hello)
 	if err != nil {
 		return Certificate{}, fmt.Errorf("custom GetCertificate: %s: %v", hello.ServerName, err)
 	}

--- a/handshake.go
+++ b/handshake.go
@@ -71,7 +71,7 @@ func (cfg *Config) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certif
 	return &cert.Certificate, err
 }
 
-// getCertificate gets a certificate that matches name from the in-memory
+// getCertificateFromCache gets a certificate that matches name from the in-memory
 // cache, according to the lookup table associated with cfg. The lookup then
 // points to a certificate in the Instance certificate cache.
 //
@@ -87,7 +87,7 @@ func (cfg *Config) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certif
 // which is by the Go Authors.
 //
 // This function is safe for concurrent use.
-func (cfg *Config) getCertificate(hello *tls.ClientHelloInfo) (cert Certificate, matched, defaulted bool) {
+func (cfg *Config) getCertificateFromCache(hello *tls.ClientHelloInfo) (cert Certificate, matched, defaulted bool) {
 	name := normalizedName(hello.ServerName)
 
 	if name == "" {
@@ -232,7 +232,7 @@ func (cfg *Config) getCertDuringHandshake(hello *tls.ClientHelloInfo, loadIfNece
 	ctx := context.TODO() // TODO: get a proper context? from somewhere...
 
 	// First check our in-memory cache to see if we've already loaded it
-	cert, matched, defaulted := cfg.getCertificate(hello)
+	cert, matched, defaulted := cfg.getCertificateFromCache(hello)
 	if matched {
 		if log != nil {
 			log.Debug("matched certificate in cache",
@@ -648,8 +648,6 @@ func (cfg *Config) renewDynamicCertificate(ctx context.Context, hello *tls.Clien
 
 		// otherwise, renew with issuer, etc.
 		var newCert Certificate
-		var err error
-    
 		if revoked {
 			newCert, err = cfg.forceRenew(ctx, log, currentCert)
 		} else {

--- a/handshake.go
+++ b/handshake.go
@@ -600,7 +600,7 @@ func (cfg *Config) renewDynamicCertificate(hello *tls.ClientHelloInfo, currentCe
 		defer cancel()
 
 		// if a custom GetCertificate is specified, just use that
-		if cfg.OnDemand.CustomGetCertificate != nil {
+		if cfg.OnDemand != nil && cfg.OnDemand.CustomGetCertificate != nil {
 			return cfg.getCertFromCustomGetCertificate(hello, log, currentCert)
 		}
 
@@ -666,6 +666,7 @@ func (cfg *Config) getCertFromCustomGetCertificate(hello *tls.ClientHelloInfo, l
 	if err != nil {
 		return Certificate{}, fmt.Errorf("custom GetCertificate: %s: filling cert from leaf: %v", hello.ServerName, err)
 	}
+	cert.managed = true // allows handshake-time maintenance/"renewal" later on
 
 	if log != nil {
 		log.Debug("using custom certificate",

--- a/handshake.go
+++ b/handshake.go
@@ -650,7 +650,7 @@ func (cfg *Config) renewDynamicCertificate(hello *tls.ClientHelloInfo, currentCe
 // It turns the result (if any) into a filled-in Certificate value, and adds it to the cache if
 // applicable (replacing oldCert, if non-empty).
 func (cfg *Config) getCertFromCustomGetCertificate(hello *tls.ClientHelloInfo, log *zap.Logger, oldCert Certificate) (Certificate, error) {
-	upstreamCert, addToCache, err := cfg.OnDemand.CustomGetCertificate(hello)
+	upstreamCert, addToCache, err := cfg.OnDemand.CustomGetCertificate.GetCertificate(hello)
 	if err != nil {
 		return Certificate{}, fmt.Errorf("custom GetCertificate: %s: %v", hello.ServerName, err)
 	}


### PR DESCRIPTION
This is useful if another entity is managing certificates and can provide its own certs dynamically during handshakes.

For example, Tailscale's client has a `GetCertificate()` function: https://pkg.go.dev/tailscale.com/client/tailscale#GetCertificate