### PR TITLE
Add TOS checker

### DIFF
--- a/acmeclient.go
+++ b/acmeclient.go
@@ -76,7 +76,7 @@ func (am *ACMEManager) newACMEClientWithAccount(ctx context.Context, useTestCA, 
 			}
 		}
 
-		// agree to terms
+		// Prompt to agree to TOS, otherwise use AccountManager's settings
 		if interactive {
 			if !am.Agreed {
 				var termsURL string
@@ -94,10 +94,6 @@ func (am *ACMEManager) newACMEClientWithAccount(ctx context.Context, useTestCA, 
 					}
 				}
 			}
-		} else {
-			// can't prompt a user who isn't there; they should
-			// have reviewed the terms beforehand
-			am.Agreed = true
 		}
 		account.TermsOfServiceAgreed = am.Agreed
 


### PR DESCRIPTION
Here's a sketch of a TOS checker that would close #164.

There might be missing locks and other standards, so let me know what needs to be changed, or directly edit them.

For my usecase in gitea it seems to be doing what I intended to do.

A few changes I want to discuss:
- Can we refactor [these lines](https://github.com/LecrisUT/certmagic/blob/c69105db56649b3bc3f86007d5b8bb0e2dcdcd9c/acmeclient.go#L80-L101) to a separate function, and make `newACMEClientWithAccount` optionally depend on it, e.g. as part of `NewAccountFunc`? The reasoning is that
  - It can be useful to have the client without accepting the TOS, e.g. in [here](https://github.com/LecrisUT/certmagic/blob/c69105db56649b3bc3f86007d5b8bb0e2dcdcd9c/acmemanager.go#L250-L258) where it is used to expose the TOS url.
  - The current implementation of the checker [overrides](https://github.com/LecrisUT/certmagic/blob/c69105db56649b3bc3f86007d5b8bb0e2dcdcd9c/acmemanager.go#L240-L247) the default assumption that `interactive == false` is the same as `TermsOfServiceAgreed == true`. It's rather inelegant to have it like such.
- I'm thinking of returning the types `bool, string, error` (`TOS_Agreed, TOS_URL, error`) to more easily distinguish if it's a TOS not being accepted or read errors. It will also be useful if the user wants to check if the TOS have changed