### PR TITLE
Fixed order of certificate loading so that private keys are loaded first

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -240,16 +240,16 @@ func (cfg *Config) loadCertResource(issuer Issuer, certNamesKey string) (Certifi
 		return CertificateResource{}, fmt.Errorf("converting '%s' to ASCII: %v", certNamesKey, err)
 	}
 
-	certBytes, err := cfg.Storage.Load(StorageKeys.SiteCert(certRes.issuerKey, normalizedName))
-	if err != nil {
-		return CertificateResource{}, err
-	}
-	certRes.CertificatePEM = certBytes
 	keyBytes, err := cfg.Storage.Load(StorageKeys.SitePrivateKey(certRes.issuerKey, normalizedName))
 	if err != nil {
 		return CertificateResource{}, err
 	}
 	certRes.PrivateKeyPEM = keyBytes
+	certBytes, err := cfg.Storage.Load(StorageKeys.SiteCert(certRes.issuerKey, normalizedName))
+	if err != nil {
+		return CertificateResource{}, err
+	}
+	certRes.CertificatePEM = certBytes
 	metaBytes, err := cfg.Storage.Load(StorageKeys.SiteMeta(certRes.issuerKey, normalizedName))
 	if err != nil {
 		return CertificateResource{}, err


### PR DESCRIPTION
The order of storing the certificates was previously changed so that the private key would be stored first. For anyone who is creating storage hooks which push the certificate & key to a 3rd party service (like a CDN), the certificates are generally refused if uploaded before the private key.

Loading can trigger the same issue if (for any reason), the certificate & key have been deleted on the 3rd party service.

I'll admit that this use-case stretches what the storage system should be doing, but the change is trivial & just matches the storing side.