### PR TITLE
increase acme client timeout to HTTPTimeout (30s)

### DIFF
--- a/acmeclient.go
+++ b/acmeclient.go
@@ -185,8 +185,8 @@ func (am *ACMEManager) newACMEClient(useTestCA bool) (*acmez.Client, error) {
 		transport := &http.Transport{
 			Proxy:                 http.ProxyFromEnvironment,
 			DialContext:           dialer.DialContext,
-			TLSHandshakeTimeout:   15 * time.Second,
-			ResponseHeaderTimeout: 15 * time.Second,
+			TLSHandshakeTimeout:   HTTPTimeout,
+			ResponseHeaderTimeout: HTTPTimeout,
 			ExpectContinueTimeout: 2 * time.Second,
 			ForceAttemptHTTP2:     true,
 		}


### PR DESCRIPTION
With an internal ACME server (keyon) we had the problem that certificate requests always timed out. Increasing the timeouts from 15s to 30s solved the issue. The timeout does not seem to be configurable?

So if this has no side effects it could be raised to the global `HTTPTimeout` setting? 