### PR TITLE
Fix crash because of a zero value cert in cache

### DIFF
--- a/maintain.go
+++ b/maintain.go
@@ -394,8 +394,7 @@ func (certCache *Cache) updateOCSPStaples(ctx context.Context) {
 	// These write locks should be brief since we have all the info we need now.
 	for certKey, update := range updated {
 		certCache.mu.Lock()
-		cert, found := certCache.cache[certKey]
-		if found {
+		if cert, ok := certCache.cache[certKey]; ok {
 			cert.ocsp = update.parsed
 			cert.Certificate.OCSPStaple = update.rawBytes
 			certCache.cache[certKey] = cert

--- a/maintain.go
+++ b/maintain.go
@@ -394,10 +394,12 @@ func (certCache *Cache) updateOCSPStaples(ctx context.Context) {
 	// These write locks should be brief since we have all the info we need now.
 	for certKey, update := range updated {
 		certCache.mu.Lock()
-		cert := certCache.cache[certKey]
-		cert.ocsp = update.parsed
-		cert.Certificate.OCSPStaple = update.rawBytes
-		certCache.cache[certKey] = cert
+		cert, found := certCache.cache[certKey]
+		if found {
+			cert.ocsp = update.parsed
+			cert.Certificate.OCSPStaple = update.rawBytes
+			certCache.cache[certKey] = cert
+		}
 		certCache.mu.Unlock()
 	}
 


### PR DESCRIPTION
Hello,

I got again the very uncommon crash I talked about on the forum: https://caddy.community/t/strange-invalid-memory-address-or-nil-pointer-dereference-with-custom-build/13867

And I'm happy to say I found the issue ! :) 
So, here is my PR to fix it, but feel free to do it in another way if you wish, as I have almost zero XP in golang.

The root cause, is updateOCSPStaples() inserting a zeroed cert into cache.

The full chain of events:
* a cert A is pushed to the `updated` queue in `updateOCSPStaples()`
* in parallel a new cert B is evicting this very same cert A from the full cache, to make some room.
* `updateOCSPStaples()` while iterating `updated` queue is trying to get cert A from cache, but got a zeroed struct, update some fields, and insert this zeroed cert to cache.
* finally a new cert C is trying to evict a random cert, if unlucky, the random cert is cert A, and so there is a call to  `removeCertificate()` on a zeroed cert, resulting in a "invalid memory address or nil pointer dereference" error

Here some extract of logs:
See cert trail.withconelabs.com being evict, **then** being updated
Also, later on we can see empty `removing_subjects` in log when trying to evict the zeroed cert

```
2022-03-19 20:00:12	{"level":"debug","ts":1647716412.2069285,"logger":"tls.cache","msg":"cache full; evicting random certificate","removing_subjects":["trail.withconelabs.com"],"removing_hash":"44ab6dbc3cee44f456d8065a9709cf894a3463ccfc2d760d3293e524f2a551a1","inserting_subjects":["trail.trymyui.app"],"inserting_hash":"03cd95e0317a1085d9869b52ad3427cba6c1fde3223c4823d862a0eb52e92678"}
2022-03-19 20:00:12	{"level":"debug","ts":1647716412.20698,"logger":"tls.cache","msg":"removed certificate from cache","subjects":["trail.withconelabs.com"],"expiration":1652399999,"managed":true,"issuer_key":"acme.zerossl.com-v2-DV90","hash":"44ab6dbc3cee44f456d8065a9709cf894a3463ccfc2d760d3293e524f2a551a1","cache_size":9999,"cache_capacity":10000}
2022-03-19 20:00:14	{"level":"info","ts":1647716414.186718,"logger":"tls.cache.maintenance","msg":"advancing OCSP staple","identifiers":["trail.withconelabs.com"],"from":1648018697,"to":1648321096}
...
2022-03-19 20:47:11 {"level":"debug","ts":1647719230.8803022,"logger":"tls.cache","msg":"cache full; evicting random certificate","removing_subjects":[],"removing_hash":"","inserting_subjects":["trail.crossingminds.com"],"inserting_hash":"e6bcb46c703993204c37d7c955bbe3a2086197f6ca8e340b08b545cf261f8f9e"}
2022-03-19 20:47:11 {"level":"debug","ts":1647719230.8815231,"logger":"http.stdlib","msg":"http: panic serving 54.174.54.48:48904: runtime error: invalid memory address or nil pointer dereference\ngoroutine 13084358 [running]:\nnet/http.(*conn).serve.func1(0xc0124617c0)\n\t/usr/local/go/src/net/http/server.go:1824 +0x153\npanic(0x16d7ac0, 0x25baad0)\n\t/usr/local/go/src/runtime/panic.go:971 +0x499\ngithub.com/caddyserver/certmagic.(*Cache).removeCertificate(0xc0002b87e0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc0087abe00, ...)\
```