### PR TITLE
Always call checkDNSPropagation in DNS01Solver

### DIFF
--- a/solvers.go
+++ b/solvers.go
@@ -337,11 +337,7 @@ func (s *DNS01Solver) Wait(ctx context.Context, challenge acme.Challenge) error 
 			return ctx.Err()
 		}
 		var ready bool
-		if s.OverrideDomain == "" {
-			ready, err = checkDNSPropagation(dnsName, keyAuth, resolvers)
-		} else {
-			ready, err = checkAuthoritativeNss(dnsName, keyAuth, resolvers)
-		}
+		ready, err = checkDNSPropagation(dnsName, keyAuth, resolvers)
 		if err != nil {
 			return fmt.Errorf("checking DNS propagation of %s: %w", dnsName, err)
 		}


### PR DESCRIPTION
Calling checkAuthoritativeNss is wrong as it's not inter-changeable with
checkDNSPropagation. See https://github.com/caddyserver/certmagic/pull/160#issuecomment-1068287592

Though IIUC it's not necessary to follow CNAME when in Wait(), with or
without OverrideDomain, let's wait until the override domain gets some
usage to change this. The reason that following CNAME is not necessary
is that CNAME cannot co-exist with other DNS records, if we succeed in
setting a TXT record on that domain, it cannot have a CNAME record.

@IndeedNotJames