### PR TITLE
Fix advanced cache initialization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,16 +238,17 @@ if err != nil {
 For more control (particularly, if you need a different way of managing each certificate), you'll make and use a `Cache` and a `Config` like so:
 
 ```go
-cache := certmagic.NewCache(certmagic.CacheOptions{
+// First make a pointer to a Cache as we need to reference the same Cache in
+// GetConfigForCert below.
+var cache *certmagic.Cache
+cache = certmagic.NewCache(certmagic.CacheOptions{
 	GetConfigForCert: func(cert certmagic.Certificate) (*certmagic.Config, error) {
-		// do whatever you need to do to get the right
-		// configuration for this certificate; keep in
-		// mind that this config value is used as a
-		// template, and will be completed with any
-		// defaults that are set in the Default config
-		return &certmagic.Config{
+		// Here we use New to get a valid Config associated with the same cache.
+		// The provided Config is used as a template and will be completed with
+		// any defaults that are set in the Default config.
+		return certmagic.New(cache, &certmagic.config{
 			// ...
-		}, nil
+		}), nil
 	},
 	...
 })

--- a/cache.go
+++ b/cache.go
@@ -145,7 +145,8 @@ type CacheOptions struct {
 	// used for managing a certificate, or for accessing
 	// that certificate's asset storage (e.g. for
 	// OCSP staples, etc). The returned Config MUST
-	// be associated with the same Cache as the caller.
+	// be associated with the same Cache as the caller,
+	// use New to obtain a valid Config.
 	//
 	// The reason this is a callback function, dynamically
 	// returning a Config (instead of attaching a static

--- a/cache.go
+++ b/cache.go
@@ -328,7 +328,11 @@ func (certCache *Cache) getConfig(cert Certificate) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	if cfg.certCache != nil && cfg.certCache != certCache {
+	if cfg.certCache == nil {
+		return nil, fmt.Errorf("config returned for certificate %v has nil cache; expected %p (this one)",
+			cert.Names, certCache)
+	}
+	if cfg.certCache != certCache {
 		return nil, fmt.Errorf("config returned for certificate %v is not nil and points to different cache; got %p, expected %p (this one)",
 			cert.Names, cfg.certCache, certCache)
 	}


### PR DESCRIPTION
Hi!

When initializing a `Cache` with `NewCache` it's easy to miss that a cache must be attached to the configuration in `CacheOptions.GetConfigForCert` and is not set by the cache itself.
If a `Config` with `certCache == nil` is used, it will cause panics at runtime (not immediately, so it's not so easy to detect the cause of the panics).

I think the proposed change to the README will address this issue and hopefully prevent other users from encountering the same problems I did, as they where not trivial to debug.

I think a good follow up discussion and possibly PR would be to look into either:
- Returning an error if `certCache == nil`, so that the error can be more easily traced to its origin.
- Filling in the `certCache` field if it's `nil`, so that the error is not possible to begin with.

I think this can be solved in `Cache.getConfig`.

It's not clear to me why the cache must be set in the `Config` returned by `GetConfigForCert` as it doesn't allow a different cache to be used in the first place (at least I think so). Since it can check whether the correct cache is used, can it simply not use the correct cache? I've not looked to deep into this, I thought it better to ask first.