### PR TITLE
Add one second (at most) to account for NotAfter imprecision

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -197,7 +197,7 @@ func (certCache *Cache) unsyncedCacheCertificate(cert Certificate) {
 		if certCache.logger != nil {
 			certCache.logger.Debug("certificate already cached",
 				zap.Strings("subjects", cert.Names),
-				zap.Time("expiration", cert.Leaf.NotAfter),
+				zap.Time("expiration", expiresAt(cert.Leaf)),
 				zap.Bool("managed", cert.managed),
 				zap.String("issuer_key", cert.issuerKey),
 				zap.String("hash", cert.hash))
@@ -242,7 +242,7 @@ func (certCache *Cache) unsyncedCacheCertificate(cert Certificate) {
 	if certCache.logger != nil {
 		certCache.logger.Debug("added certificate to cache",
 			zap.Strings("subjects", cert.Names),
-			zap.Time("expiration", cert.Leaf.NotAfter),
+			zap.Time("expiration", expiresAt(cert.Leaf)),
 			zap.Bool("managed", cert.managed),
 			zap.String("issuer_key", cert.issuerKey),
 			zap.String("hash", cert.hash),
@@ -278,7 +278,7 @@ func (certCache *Cache) removeCertificate(cert Certificate) {
 	if certCache.logger != nil {
 		certCache.logger.Debug("removed certificate from cache",
 			zap.Strings("subjects", cert.Names),
-			zap.Time("expiration", cert.Leaf.NotAfter),
+			zap.Time("expiration", expiresAt(cert.Leaf)),
 			zap.Bool("managed", cert.managed),
 			zap.String("issuer_key", cert.issuerKey),
 			zap.String("hash", cert.hash),
@@ -299,7 +299,7 @@ func (certCache *Cache) replaceCertificate(oldCert, newCert Certificate) {
 	if certCache.logger != nil {
 		certCache.logger.Info("replaced certificate in cache",
 			zap.Strings("subjects", newCert.Names),
-			zap.Time("new_expiration", newCert.Leaf.NotAfter))
+			zap.Time("new_expiration", expiresAt(newCert.Leaf)))
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -1065,8 +1065,8 @@ func (cfg *Config) managedCertNeedsRenewal(certRes CertificateResource) (time.Du
 	if err != nil {
 		return 0, true
 	}
-	remaining := time.Until(certChain[0].NotAfter)
-	needsRenew := currentlyInRenewalWindow(certChain[0].NotBefore, certChain[0].NotAfter, cfg.RenewalWindowRatio)
+	remaining := time.Until(expiresAt(certChain[0]))
+	needsRenew := currentlyInRenewalWindow(certChain[0].NotBefore, expiresAt(certChain[0]), cfg.RenewalWindowRatio)
 	return remaining, needsRenew
 }
 

--- a/crypto.go
+++ b/crypto.go
@@ -229,7 +229,7 @@ func (cfg *Config) loadCertResourceAnyIssuer(ctx context.Context, certNamesKey s
 	if cfg.Logger != nil {
 		cfg.Logger.Debug("loading managed certificate",
 			zap.String("domain", certNamesKey),
-			zap.Time("expiration", certResources[0].decoded.NotAfter),
+			zap.Time("expiration", expiresAt(certResources[0].decoded)),
 			zap.String("issuer_key", certResources[0].issuer.IssuerKey()),
 			zap.Any("storage", cfg.Storage),
 		)

--- a/handshake.go
+++ b/handshake.go
@@ -214,7 +214,7 @@ func DefaultCertificateSelector(hello *tls.ClientHelloInfo, choices []Certificat
 			continue
 		}
 		best = choice // at least the client supports it...
-		if now.After(choice.Leaf.NotBefore) && now.Before(choice.Leaf.NotAfter) {
+		if now.After(choice.Leaf.NotBefore) && now.Before(expiresAt(choice.Leaf)) {
 			return choice, nil // ...and unexpired, great! "Certificate, I choose you!"
 		}
 	}
@@ -246,7 +246,7 @@ func (cfg *Config) getCertDuringHandshake(hello *tls.ClientHelloInfo, loadIfNece
 			log.Debug("matched certificate in cache",
 				zap.Strings("subjects", cert.Names),
 				zap.Bool("managed", cert.managed),
-				zap.Time("expiration", cert.Leaf.NotAfter),
+				zap.Time("expiration", expiresAt(cert.Leaf)),
 				zap.String("hash", cert.hash))
 		}
 		if cert.managed && cfg.OnDemand != nil && obtainIfNecessary {
@@ -306,7 +306,7 @@ func (cfg *Config) getCertDuringHandshake(hello *tls.ClientHelloInfo, loadIfNece
 				log.Debug("loaded certificate from storage",
 					zap.Strings("subjects", loadedCert.Names),
 					zap.Bool("managed", loadedCert.managed),
-					zap.Time("expiration", loadedCert.Leaf.NotAfter),
+					zap.Time("expiration", expiresAt(loadedCert.Leaf)),
 					zap.String("hash", loadedCert.hash))
 			}
 			loadedCert, err = cfg.handshakeMaintenance(ctx, hello, loadedCert)
@@ -331,7 +331,7 @@ func (cfg *Config) getCertDuringHandshake(hello *tls.ClientHelloInfo, loadIfNece
 			log.Debug("fell back to default certificate",
 				zap.Strings("subjects", cert.Names),
 				zap.Bool("managed", cert.managed),
-				zap.Time("expiration", cert.Leaf.NotAfter),
+				zap.Time("expiration", expiresAt(cert.Leaf)),
 				zap.String("hash", cert.hash))
 		}
 		return cert, nil
@@ -364,7 +364,7 @@ func (cfg *Config) optionalMaintenance(ctx context.Context, log *zap.Logger, cer
 	if log != nil {
 		log.Error("renewing certificate on-demand failed",
 			zap.Strings("subjects", cert.Names),
-			zap.Time("not_after", cert.Leaf.NotAfter),
+			zap.Time("not_after", expiresAt(cert.Leaf)),
 			zap.Error(err))
 	}
 
@@ -537,7 +537,7 @@ func (cfg *Config) handshakeMaintenance(ctx context.Context, hello *tls.ClientHe
 	}
 
 	// Check cert expiration
-	if currentlyInRenewalWindow(cert.Leaf.NotBefore, cert.Leaf.NotAfter, cfg.RenewalWindowRatio) {
+	if currentlyInRenewalWindow(cert.Leaf.NotBefore, expiresAt(cert.Leaf), cfg.RenewalWindowRatio) {
 		return cfg.renewDynamicCertificate(ctx, hello, cert)
 	}
 
@@ -559,7 +559,7 @@ func (cfg *Config) renewDynamicCertificate(ctx context.Context, hello *tls.Clien
 	log := loggerNamed(cfg.Logger, "on_demand")
 
 	name := cfg.getNameFromClientHello(hello)
-	timeLeft := time.Until(currentCert.Leaf.NotAfter)
+	timeLeft := time.Until(expiresAt(currentCert.Leaf))
 	revoked := currentCert.ocsp != nil && currentCert.ocsp.Status == ocsp.Revoked
 
 	getCertWithoutReobtaining := func() (Certificate, error) {
@@ -592,7 +592,7 @@ func (cfg *Config) renewDynamicCertificate(ctx context.Context, hello *tls.Clien
 		if log != nil {
 			log.Debug("certificate has expired, but is already being renewed; waiting for renewal to complete",
 				zap.Strings("subjects", currentCert.Names),
-				zap.Time("expired", currentCert.Leaf.NotAfter),
+				zap.Time("expired", expiresAt(currentCert.Leaf)),
 				zap.Bool("revoked", revoked))
 		}
 
@@ -624,7 +624,7 @@ func (cfg *Config) renewDynamicCertificate(ctx context.Context, hello *tls.Clien
 		log.Info("attempting certificate renewal",
 			zap.String("server_name", name),
 			zap.Strings("subjects", currentCert.Names),
-			zap.Time("expiration", currentCert.Leaf.NotAfter),
+			zap.Time("expiration", expiresAt(currentCert.Leaf)),
 			zap.Duration("remaining", timeLeft),
 			zap.Bool("revoked", revoked))
 	}
@@ -739,7 +739,7 @@ func (cfg *Config) getCertFromAnyCertManager(ctx context.Context, hello *tls.Cli
 		log.Debug("using externally-managed certificate",
 			zap.String("sni", hello.ServerName),
 			zap.Strings("names", cert.Names),
-			zap.Time("expiration", cert.Leaf.NotAfter))
+			zap.Time("expiration", expiresAt(cert.Leaf)))
 	}
 
 	return cert, nil

--- a/maintain.go
+++ b/maintain.go
@@ -180,7 +180,7 @@ func (certCache *Cache) RenewManagedCertificates(ctx context.Context) error {
 
 	// Reload certificates that merely need to be updated in memory
 	for _, oldCert := range reloadQueue {
-		timeLeft := oldCert.Leaf.NotAfter.Sub(time.Now().UTC())
+		timeLeft := expiresAt(oldCert.Leaf).Sub(time.Now().UTC())
 		if log != nil {
 			log.Info("certificate expires soon, but is already renewed in storage; reloading stored certificate",
 				zap.Strings("identifiers", oldCert.Names),
@@ -228,7 +228,7 @@ func (certCache *Cache) RenewManagedCertificates(ctx context.Context) error {
 func (certCache *Cache) queueRenewalTask(ctx context.Context, oldCert Certificate, cfg *Config) error {
 	log := loggerNamed(certCache.logger, "maintenance")
 
-	timeLeft := oldCert.Leaf.NotAfter.Sub(time.Now().UTC())
+	timeLeft := expiresAt(oldCert.Leaf).Sub(time.Now().UTC())
 	if log != nil {
 		log.Info("certificate expires soon; queuing for renewal",
 			zap.Strings("identifiers", oldCert.Names),
@@ -242,7 +242,7 @@ func (certCache *Cache) queueRenewalTask(ctx context.Context, oldCert Certificat
 
 	// queue up this renewal job (is a no-op if already active or queued)
 	jm.Submit(cfg.Logger, "renew_"+renewName, func() error {
-		timeLeft := oldCert.Leaf.NotAfter.Sub(time.Now().UTC())
+		timeLeft := expiresAt(oldCert.Leaf).Sub(time.Now().UTC())
 		if log != nil {
 			log.Info("attempting certificate renewal",
 				zap.Strings("identifiers", oldCert.Names),
@@ -522,7 +522,7 @@ func deleteExpiredCerts(ctx context.Context, storage Storage, gracePeriod time.D
 					return fmt.Errorf("certificate file %s is malformed; error parsing PEM: %v", assetKey, err)
 				}
 
-				if expiredTime := time.Since(cert.NotAfter); expiredTime >= gracePeriod {
+				if expiredTime := time.Since(expiresAt(cert)); expiredTime >= gracePeriod {
 					log.Printf("[INFO] Certificate %s expired %s ago; cleaning up", assetKey, expiredTime)
 					baseName := strings.TrimSuffix(assetKey, ".crt")
 					for _, relatedAsset := range []string{
@@ -564,11 +564,11 @@ func (cfg *Config) forceRenew(ctx context.Context, logger *zap.Logger, cert Cert
 		if cert.ocsp != nil && cert.ocsp.Status == ocsp.Revoked {
 			logger.Warn("OCSP status for managed certificate is REVOKED; attempting to replace with new certificate",
 				zap.Strings("identifiers", cert.Names),
-				zap.Time("expiration", cert.Leaf.NotAfter))
+				zap.Time("expiration", expiresAt(cert.Leaf)))
 		} else {
 			logger.Warn("forcefully renewing certificate",
 				zap.Strings("identifiers", cert.Names),
-				zap.Time("expiration", cert.Leaf.NotAfter))
+				zap.Time("expiration", expiresAt(cert.Leaf)))
 		}
 	}
 

--- a/ocsp.go
+++ b/ocsp.go
@@ -98,12 +98,12 @@ func stapleOCSP(ctx context.Context, ocspConfig OCSPConfig, storage Storage, cer
 		gotNewOCSP = true
 	}
 
-	if ocspResp.NextUpdate.After(cert.Leaf.NotAfter) {
+	if ocspResp.NextUpdate.After(expiresAt(cert.Leaf)) {
 		// uh oh, this OCSP response expires AFTER the certificate does, that's kinda bogus.
 		// it was the reason a lot of Symantec-validated sites (not Caddy) went down
 		// in October 2017. https://twitter.com/mattiasgeniar/status/919432824708648961
 		return fmt.Errorf("invalid: OCSP response for %v valid after certificate expiration (%s)",
-			cert.Names, cert.Leaf.NotAfter.Sub(ocspResp.NextUpdate))
+			cert.Names, expiresAt(cert.Leaf).Sub(ocspResp.NextUpdate))
 	}
 
 	// Attach the latest OCSP response to the certificate; this is NOT the same


### PR DESCRIPTION
Here is a PR to fix #197. I ended up going with a function instead of a method on `Certificate` because there are a couple places where the `NotAfter` of a `x509.Certificate` are being used. I also had a hard time figuring out how to write a test for this. It looked like the filesystem storage cache needs to be populated with a certificate and ocsp response, but i didn't see a straightforward way or any prior examples of this in other tests. Let me know if you have any thoughts on how to test this.