### PR TITLE
Avoid nil dereferencing on errors

### DIFF
--- a/config.go
+++ b/config.go
@@ -785,7 +785,9 @@ func (cfg *Config) renewCert(ctx context.Context, name string, force, interactiv
 		// try to obtain from each issuer until we succeed
 		var issuedCert *IssuedCertificate
 		var issuerUsed Issuer
+		var issuerKeys []string
 		for _, issuer := range cfg.Issuers {
+			issuerKeys = append(issuerKeys, issuer.IssuerKey())
 			if prechecker, ok := issuer.(PreChecker); ok {
 				err = prechecker.PreCheck(ctx, []string{name}, interactive)
 				if err != nil {
@@ -818,7 +820,7 @@ func (cfg *Config) renewCert(ctx context.Context, name string, force, interactiv
 				"renewal":     true,
 				"identifier":  name,
 				"remaining":   timeLeft,
-				"issuer":      issuerUsed.IssuerKey(),
+				"issuers":     issuerKeys,
 				"storage_key": certRes.NamesKey(),
 				"error":       err,
 			})


### PR DESCRIPTION
## What were you doing?

Requesting a certificate failed, and then additionally caused rate limiting issues as well.

Certmagic version: 0.17.1

This merges #204 to a similar place in config.go.

---
Stack we have seen:

```
  | 2022-09-23T10:46:17.120Z | {"level":"error","time":"2022-09-23T10:46:17Z","module":"cert.renew","caller":"certmagic/config.go:810","msg":"could not get certificate from issuer","identifier":"XXX","issuer":"acme-v02.api.letsencrypt.org-directory","error":"HTTP 429 urn:ietf:params:acme:error:rateLimited - Error creating new order :: too many failed authorizations recently: see https://letsencrypt.org/docs/failed-validation-limit/","stacktrace":"github.com/caddyserver/certmagic.(*Config).renewCert.func2\n\t/src/vendor/github.com/caddyserver/certmagic/config.go:810\ngithub.com/caddyserver/certmagic.doWithRetry\n\t/src/vendor/github.com/caddyserver/certmagic/async.go:106\ngithub.com/caddyserver/certmagic.(*Config).renewCert\n\t/src/vendor/github.com/caddyserver/certmagic/config.go:860\ngithub.com/caddyserver/certmagic.(*Config).RenewCertAsync\n\t/src/vendor/github.com/caddyserver/certmagic/config.go:690\ngithub.com/caddyserver/certmagic.(*Config).renewDynamicCertificate.func3\n\t/src/vendor/github.com/caddyserver/certmagic/handshake.go:664"}
  | 2022-09-23T10:46:17.120Z | {"level":"info","time":"2022-09-23T10:46:17Z","module":"cert.renew","caller":"certmagic/config.go:719","msg":"releasing lock","identifier":"XXX"}
  | 2022-09-23T10:46:17.127Z | panic: runtime error: invalid memory address or nil pointer dereference
  | 2022-09-23T10:46:17.127Z | [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xbc9db4]
  | 2022-09-23T10:46:17.127Z | goroutine 52862 [running]:
  | 2022-09-23T10:46:17.127Z | github.com/caddyserver/certmagic.(*Config).renewCert.func2({0x1450720, 0xc00c9e9590})
  | 2022-09-23T10:46:17.127Z | /src/vendor/github.com/caddyserver/certmagic/config.go:821 +0xc14
  | 2022-09-23T10:46:17.127Z | github.com/caddyserver/certmagic.doWithRetry({0x14506e8, 0xc000360360}, 0xc006f596c0, 0xc00776f720)
  | 2022-09-23T10:46:17.127Z | /src/vendor/github.com/caddyserver/certmagic/async.go:106 +0x1cb
  | 2022-09-23T10:46:17.128Z | github.com/caddyserver/certmagic.(*Config).renewCert(0xc00015b550, {0x14506e8, 0xc000360360}, {0xc003cbcfa0, 0xc}, 0x0, 0x0)
  | 2022-09-23T10:46:17.128Z | /src/vendor/github.com/caddyserver/certmagic/config.go:860 +0x58b
  | 2022-09-23T10:46:17.128Z | github.com/caddyserver/certmagic.(*Config).RenewCertAsync(...)
  | 2022-09-23T10:46:17.128Z | /src/vendor/github.com/caddyserver/certmagic/config.go:690
  | 2022-09-23T10:46:17.128Z | github.com/caddyserver/certmagic.(*Config).renewDynamicCertificate.func3({0x14506e8, 0xc000360360}, 0xc0001f7f20?)
  | 2022-09-23T10:46:17.128Z | /src/vendor/github.com/caddyserver/certmagic/handshake.go:664 +0x2ac
  | 2022-09-23T10:46:17.128Z | created by github.com/caddyserver/certmagic.(*Config).renewDynamicCertificate
  | 2022-09-23T10:46:17.128Z | /src/vendor/github.com/caddyserver/certmagic/handshake.go:699 +0x1293
```