### PR TITLE
Fix a panic when attempting to log when certificate should not be renewed

### DIFF
--- a/handshake.go
+++ b/handshake.go
@@ -652,7 +652,11 @@ func (cfg *Config) renewDynamicCertificate(ctx context.Context, hello *tls.Clien
 			cfg.certCache.removeCertificate(currentCert)
 			cfg.certCache.mu.Unlock()
 			unblockWaiters()
-			log.Error("certificate should not be obtained", zap.Error(err))
+
+			if log != nil {
+				log.Error("certificate should not be obtained", zap.Error(err))
+			}
+
 			return Certificate{}, err
 		}
 


### PR DESCRIPTION
In v0.17.1, we're seeing the following panic occur (and subsequently, no recovery) over at [sish](https://github.com/antoniomika/sish). 

This occurs because we don't use zap for logging, which leads to `loggerNamed` returning `nil`. I went through and checked all other logger references and made sure they are guarded by the same issue by checking that `log` is not `nil`.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa1f3ca]

goroutine 537 [running]:
go.uber.org/zap.(*Logger).check(0x0, 0x2, {0xc8e025, 0x22})
	/go/pkg/mod/go.uber.org/zap@v1.23.0/logger.go:291 +0x6a
go.uber.org/zap.(*Logger).Error(0xc0000ee038?, {0xc8e025?, 0x4?}, {0xc00071d300, 0x1, 0x1})
	/go/pkg/mod/go.uber.org/zap@v1.23.0/logger.go:228 +0x3e
github.com/caddyserver/certmagic.(*Config).renewDynamicCertificate.func3({0xdbb248, 0xc001529da0}, 0xc00011acc0?)
	/go/pkg/mod/github.com/caddyserver/certmagic@v0.17.1/handshake.go:655 +0xbb7
created by github.com/caddyserver/certmagic.(*Config).renewDynamicCertificate
	/go/pkg/mod/github.com/caddyserver/certmagic@v0.17.1/handshake.go:699 +0x1293
```