### PR TITLE
obtain instead of renew cert if it does not exist in storage

### DIFF
--- a/handshake.go
+++ b/handshake.go
@@ -500,14 +500,6 @@ func (cfg *Config) obtainOnDemandCertificate(ctx context.Context, hello *tls.Cli
 func (cfg *Config) handshakeMaintenance(ctx context.Context, hello *tls.ClientHelloInfo, cert Certificate) (Certificate, error) {
 	log := cfg.Logger.Named("on_demand")
 
-	// Check if the certificate still exists on disk. If not, we need to obtain a new one.
-	if !cfg.storageHasCertResourcesAnyIssuer(ctx, cert.Names[0]) {
-		log.Debug("certificate not found on disk; obtaining new certificate",
-			zap.Strings("identifiers", cert.Names))
-
-		return cfg.obtainOnDemandCertificate(ctx, hello)
-	}
-
 	// Check OCSP staple validity
 	if cert.ocsp != nil && !freshOCSP(cert.ocsp) {
 		log.Debug("OCSP response needs refreshing",
@@ -551,6 +543,16 @@ func (cfg *Config) handshakeMaintenance(ctx context.Context, hello *tls.ClientHe
 
 	// Check cert expiration
 	if currentlyInRenewalWindow(cert.Leaf.NotBefore, expiresAt(cert.Leaf), cfg.RenewalWindowRatio) {
+		// Check if the certificate still exists on disk. If not, we need to obtain a new one.
+		// This can happen if the certificate was cleaned up by the storage cleaner, but still
+		// remains in the in-memory cache.
+		if !cfg.storageHasCertResourcesAnyIssuer(ctx, cert.Names[0]) {
+			log.Debug("certificate not found on disk; obtaining new certificate",
+				zap.Strings("identifiers", cert.Names))
+
+			return cfg.obtainOnDemandCertificate(ctx, hello)
+		}
+		// Otherwise, renew the certificate.
 		return cfg.renewDynamicCertificate(ctx, hello, cert)
 	}
 


### PR DESCRIPTION
This is a proposed fix for the issue reported in https://github.com/caddyserver/certmagic/issues/220.

Instead of always renewing the certificate, we first check if the corresponding resources still exist in the storage and if not use the "obtain" instead of the "renew" flow.