### PR TITLE
Use recursive query when checking for TXT records

### DIFF
--- a/dnsutil.go
+++ b/dnsutil.go
@@ -237,7 +237,7 @@ func checkDNSPropagation(fqdn, value string, resolvers []string) (bool, error) {
 // checkAuthoritativeNss queries each of the given nameservers for the expected TXT record.
 func checkAuthoritativeNss(fqdn, value string, nameservers []string) (bool, error) {
 	for _, ns := range nameservers {
-		r, err := dnsQuery(fqdn, dns.TypeTXT, []string{net.JoinHostPort(ns, "53")}, false)
+		r, err := dnsQuery(fqdn, dns.TypeTXT, []string{net.JoinHostPort(ns, "53")}, true)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
I am using the DNS challenge with the cloudflare plugin. It fails to get a certificate and results in a DNS propagation timeout error: https://github.com/caddyserver/certmagic/blob/6b92945f9db40001ef2a90a1b2c6c234e9ebddd3/solvers.go#L384

1. The cloudflare plugin successfully adds the correct TXT DNS records.
2. Running `dig -t TXT  _acme-challenge.sub.domain.com @1.1.1.1` on the caddy host machine correctly shows the TXT record very soon after the cloudflare dashboard shows the records. (So well before the default 2 minute propagation timeout)
3. Running `tcpdump port 53 and host 1.1.1.1` shows DNS queries happening every 2 seconds from caddy to 1.1.1.1. 1.1.1.1 correctly replies with the TXT records.
4. caddy appears to completely ignore the provided TXT records and eventually times out.

After some testing using the code in `dnsutil.go`, changing the recursive flag from `false` to `true` seems to result in a `dns.Msg` which now correctly contains the TXT records.