### PR TITLE
Add a `GetCertificateWithContext` function

### DIFF
--- a/handshake.go
+++ b/handshake.go
@@ -42,9 +42,15 @@ import (
 // 5. Issuers (if on-demand is enabled)
 //
 // This method is safe for use as a tls.Config.GetCertificate callback.
+//
+// GetCertificate will run in a new context, use GetCertificateWithContext to provide
+// a context.
 func (cfg *Config) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	ctx := context.TODO() // TODO: get a proper context? from somewhere...
+	return cfg.GetCertificateWithContext(ctx, clientHello)
+}
 
+func (cfg *Config) GetCertificateWithContext(ctx context.Context, clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	if err := cfg.emit(ctx, "tls_get_certificate", map[string]any{"client_hello": clientHello}); err != nil {
 		cfg.Logger.Error("TLS handshake aborted by event handler",
 			zap.String("server_name", clientHello.ServerName),


### PR DESCRIPTION
This basically would allow us to pass a context into the "certmagic world", from which it then would get passed through back to our storage implementation.

The reason we want that is so that we can actually set up application performance monitoring by instrumenting the calls.

Note that this does add a new public function, but unless you specifically set your `GetCertificate` in the TLSConfig to something that uses this function, everything should stay the same.

Our setup looks like this, very simplified:

```golang
certmagicConfig.Issuers = []certmagic.Issuer{acmeIssuer}

tlsConfig := certmagicConfig.TLSConfig()
tlsConfig.GetCertificate = func(clientHelloInfo *tls.ClientHelloInfo) (*tls.Certificate, error) {
	txn := monitoring.StartTransaction("TLS/GetCertificate")
	defer txn.End()
	txn.AddAttribute("hostname", clientHelloInfo.ServerName)
	txn.AddAttribute("supportedVersions", supportedVersionsToString(clientHelloInfo.SupportedVersions))

	// ... do some checks here to make sure we want to handle this request

	ctx := newrelic.NewContext(context.Background(), txn)
	cert, err := certmagicConfig.GetCertificateWithContext(ctx, clientHelloInfo)
	if err != nil {
		// ... review the error and possible ignore it/handle it differently
	}
	return cert, err
}
```
