### PR TITLE
Update & Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,5 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v3
       with:
-        name: code-coverage-report
+        name: ${{ runner.os }}-code-coverage-report
         path: "cover-profile.out"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,28 +39,11 @@ jobs:
         env
         # Calculate the short SHA1 hash of the git commit
         echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
-
-#   - name: Cache the build cache
-#     uses: actions/cache@v2
-#     with:
-#       # In order:
-#       # * Module download cache
-#       # * Build cache (Linux)
-#       # * Build cache (Mac)
-#       # * Build cache (Windows)
-#       path: |
-#         ~/go/pkg/mod
-#         ~/.cache/go-build
-#         ~/Library/Caches/go-build
-#         ~\AppData\Local\go-build
-#       key: ${{ runner.os }}-${{ matrix.go }}-go-ci-${{ hashFiles('**/go.sum') }}
-#       restore-keys: |
-#         ${{ runner.os }}-${{ matrix.go }}-go-ci
-#
-#   - name: Get dependencies
-#     run: |
-#       go get -v -t -d ./...
-#
+ 
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+ 
     - name: Run tests
       run: |
         go test -v -coverprofile="cover-profile.out" -short -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod' # Install go version consistent with project
-        cache-dependency-path: 'go.sum' # Cache dependencies
 
     - name: Print Go version and environment
       id: vars

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        go: [ '1.18' ]
 
     runs-on: ${{ matrix.os }}
 
@@ -25,7 +26,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version-file: 'go.mod' # Install go version consistent with project
+        go-version: ${{ matrix.go }}
 
     - name: Print Go version and environment
       id: vars
@@ -36,18 +37,10 @@ jobs:
         go env
         printf "\n\nSystem environment:\n\n"
         env
-        # Calculate the short SHA1 hash of the git commit
-        echo "{short_sha}={ $(git rev-parse --short HEAD) }" >> $GITHUB_OUTPUT
  
     - name: Install dependencies
       run: go mod download
  
     - name: Run tests
       run: |
-        go test -v -coverprofile="cover-profile.out" -short -race ./...
-        
-    - name: Archive code coverage results
-      uses: actions/upload-artifact@v3
-      with:
-        name: ${{ runner.os }}-code-coverage-report
-        path: "cover-profile.out"
+        go test -v -short -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version-file: 'go.mod' # Install go version consistent with project setup
+        go-version-file: 'go.mod' # Install go version consistent with project
         cache-dependency-path: 'go.sum' # Cache dependencies
 
     - name: Print Go version and environment
@@ -40,9 +40,8 @@ jobs:
         # Calculate the short SHA1 hash of the git commit
         echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
  
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
+    - name: Install dependencies
+      run: go mod download
  
     - name: Run tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go: [ '1.18' ]
+        go: [ '1.18', '1.20' ]
 
     runs-on: ${{ matrix.os }}
 
@@ -42,5 +42,4 @@ jobs:
       run: go mod download
  
     - name: Run tests
-      run: |
-        go test -v -short -race ./...
+      run: go test -v -short -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         printf "\n\nSystem environment:\n\n"
         env
         # Calculate the short SHA1 hash of the git commit
-        echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+        echo "{short_sha}={ $(git rev-parse --short HEAD) }" >> $GITHUB_OUTPUT
  
     - name: Install dependencies
       run: go mod download

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,4 @@ jobs:
     - name: Run tests
       run: |
         go test -v -coverprofile="cover-profile.out" -short -race ./...
+#

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,18 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go: [ '1.18' ]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
-
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: 'go.mod' # Install go version consistent with project setup
+        cache-dependency-path: 'go.sum' # Cache dependencies
 
     - name: Print Go version and environment
       id: vars
@@ -40,26 +40,26 @@ jobs:
         # Calculate the short SHA1 hash of the git commit
         echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
 
-    - name: Cache the build cache
-      uses: actions/cache@v2
-      with:
-        # In order:
-        # * Module download cache
-        # * Build cache (Linux)
-        # * Build cache (Mac)
-        # * Build cache (Windows)
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          ~\AppData\Local\go-build
-        key: ${{ runner.os }}-${{ matrix.go }}-go-ci-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.go }}-go-ci
+#   - name: Cache the build cache
+#     uses: actions/cache@v2
+#     with:
+#       # In order:
+#       # * Module download cache
+#       # * Build cache (Linux)
+#       # * Build cache (Mac)
+#       # * Build cache (Windows)
+#       path: |
+#         ~/go/pkg/mod
+#         ~/.cache/go-build
+#         ~/Library/Caches/go-build
+#         ~\AppData\Local\go-build
+#       key: ${{ runner.os }}-${{ matrix.go }}-go-ci-${{ hashFiles('**/go.sum') }}
+#       restore-keys: |
+#         ${{ runner.os }}-${{ matrix.go }}-go-ci
 
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
+#   - name: Get dependencies
+#     run: |
+#       go get -v -t -d ./...
 
     - name: Run tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,9 @@ jobs:
     - name: Run tests
       run: |
         go test -v -coverprofile="cover-profile.out" -short -race ./...
+        
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v3
+      with:
+        name: code-coverage-report
+        path: "cover-profile.out"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,3 @@ jobs:
     - name: Run tests
       run: |
         go test -v -coverprofile="cover-profile.out" -short -race ./...
-#

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,11 @@ jobs:
 #       key: ${{ runner.os }}-${{ matrix.go }}-go-ci-${{ hashFiles('**/go.sum') }}
 #       restore-keys: |
 #         ${{ runner.os }}-${{ matrix.go }}-go-ci
-
+#
 #   - name: Get dependencies
 #     run: |
 #       go get -v -t -d ./...
-
+#
     - name: Run tests
       run: |
         go test -v -coverprofile="cover-profile.out" -short -race ./...


### PR DESCRIPTION
Hi, this CI updates the CI workflow file.
This PR:
- Updates `checkout` v2 -> v3
- Updates `setup-go` v2 -> v4
- Configures `setup-go` to use the go version consistent with project setup via `go.mod` file
- Delegates build caching to `setup-go`
- Changes dependency installation to `go mod download` ([official documentation](https://go.dev/ref/mod#go-mod-download), [difference with the current `go get`](https://stackoverflow.com/questions/66356034/what-is-the-difference-between-go-get-command-and-go-mod-download-command))
- Replaces the deprecated `set-output`
- Uploads coverage file as an artifact, as currently the generated file is discarded