### PR TITLE
README: Add hint about NextProtos for certmagic.TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ tlsConfig, err := certmagic.TLS([]string{"example.com"})
 if err != nil {
 	return err
 }
+// be sure to customize NextProtos if serving a specific
+// application protocol after the TLS handshake, for example:
+tlsConfig.NextProtos = append([]string{"h2", "http/1.1"}, tlsConfig.NextProtos...)
 ```
 
 


### PR DESCRIPTION
This hint is already present a couple of lines later, however I overlooked it in the large advanced usescase.

In my usecase I just want to customize the storage:
```go
		// SETUP TLS
		certmagic.DefaultACME.Email = "redacted@example.org"
		certmagic.DefaultACME.Agreed = true
		certmagic.DefaultACME.DisableHTTPChallenge = true

		// bugfix will come here

		certConfig := certmagic.NewDefault()
		certConfig.Storage = &certmagic.FileStorage{
			Path: stateDir + ".certmagic",
		}
		tlsConfig := certConfig.TLSConfig()
		tlsConfig.NextProtos = append([]string{"h2", "http/1.1"}, tlsConfig.NextProtos...)

		ln, err = tls.Listen("tcp", addr, tlsConfig)
		if err != nil {
			return err
		}

		if err := certConfig.ManageAsync(ctx, domains); err != nil { // async to prevent systemd restart
			return fmt.Errorf("could not manage TLS certificates: %v", err)
		}
```