### PR TITLE
Optionally pass the context argument down to the OnDemand decision func

### DIFF
--- a/certmagic.go
+++ b/certmagic.go
@@ -268,7 +268,18 @@ type OnDemandConfig struct {
 	// whether a certificate can be obtained or renewed
 	// for the given name. If an error is returned, the
 	// request will be denied.
+	// If both this and DecisionContextFunc are set, only
+	// DecisionContextFunc will be used.
+	// Deprecated: Use DecisionContextFunc instead.
 	DecisionFunc func(name string) error
+
+	// If set, this function will be called to determine
+	// whether a certificate can be obtained or renewed
+	// for the given name. If an error is returned, the
+	// request will be denied.
+	// If both this and DecisionContextFunc are set, only
+	// DecisionContextFunc will be used.
+	DecisionContextFunc func(ctx context.Context, name string) error
 
 	// Sources for getting new, unmanaged certificates.
 	// They will be invoked only during TLS handshakes

--- a/certmagic.go
+++ b/certmagic.go
@@ -268,18 +268,7 @@ type OnDemandConfig struct {
 	// whether a certificate can be obtained or renewed
 	// for the given name. If an error is returned, the
 	// request will be denied.
-	// If both this and DecisionContextFunc are set, only
-	// DecisionContextFunc will be used.
-	// Deprecated: Use DecisionContextFunc instead.
-	DecisionFunc func(name string) error
-
-	// If set, this function will be called to determine
-	// whether a certificate can be obtained or renewed
-	// for the given name. If an error is returned, the
-	// request will be denied.
-	// If both this and DecisionContextFunc are set, only
-	// DecisionContextFunc will be used.
-	DecisionContextFunc func(ctx context.Context, name string) error
+	DecisionFunc func(ctx context.Context, name string) error
 
 	// Sources for getting new, unmanaged certificates.
 	// They will be invoked only during TLS handshakes

--- a/handshake.go
+++ b/handshake.go
@@ -446,14 +446,8 @@ func (cfg *Config) checkIfCertShouldBeObtained(ctx context.Context, name string,
 		return fmt.Errorf("subject name does not qualify for certificate: %s", name)
 	}
 	if cfg.OnDemand != nil {
-		if cfg.OnDemand.DecisionContextFunc != nil {
-			if err := cfg.OnDemand.DecisionContextFunc(ctx, name); err != nil {
-				return fmt.Errorf("decision func: %w", err)
-			}
-			return nil
-		}
 		if cfg.OnDemand.DecisionFunc != nil {
-			if err := cfg.OnDemand.DecisionFunc(name); err != nil {
+			if err := cfg.OnDemand.DecisionFunc(ctx, name); err != nil {
 				return fmt.Errorf("decision func: %w", err)
 			}
 			return nil


### PR DESCRIPTION
For further instrumenting our code base we would like to be able to pass the context we have when getting a certificate down into the "decision func" that checks whether a certificate should be obtained.

This PR is a bit of a "let's talk": I think this could just work, and wouldn't produce problems for existing code that only configures a `DecisionFunc`, but it can possibly be done nicer?