### PR TITLE
Retain the error stack if `checkIfCertShouldBeObtained` returns an error

### DIFF
--- a/handshake.go
+++ b/handshake.go
@@ -314,7 +314,7 @@ func (cfg *Config) getCertDuringHandshake(ctx context.Context, hello *tls.Client
 	// make sense to try loading one from storage (issue #185), getting it from a
 	// certificate manager, or obtaining one from an issuer.
 	if err := cfg.checkIfCertShouldBeObtained(ctx, name, false); err != nil {
-		return Certificate{}, fmt.Errorf("certificate is not allowed for server name %s: %v", name, err)
+		return Certificate{}, fmt.Errorf("certificate is not allowed for server name %s: %w", name, err)
 	}
 
 	// If an external Manager is configured, try to get it from them.


### PR DESCRIPTION
This allows an outside caller of `GetCertificate` to use `errors.As` to check for their own response and react accordingly.

In our case: The ondemand decision func checks a blocklist and might return something like `BlockedDomainError{message:"This is blocked"}`. This isn't an "error", it's just something that so happens to look like an error because that's what the decision func wants us to return.

In the GetCertificate implementation we call certmagic, and check the error it returns. If the error is "expected", then we don't really care about it and might just count it. If it is something interesting, we might want to tell a human about it.
The way that works is by having the `GetCertificate` function in a NewRelic "Transaction", and when we receive an error from certmagic we check whether the error is of one of the "normal" types, and if so call `txn.NoticeExpectedError(err)`. If it is interesting, we call `NoticeError(err)`.

This doesn't work for the errors from the decision func, because those lose their causal trace. The PR fixes that by using `%w` instead of `%v` to transmit the error outwards.
