### PR TITLE
Retry with new account if account disappeared remotely

### DIFF
--- a/account.go
+++ b/account.go
@@ -171,6 +171,16 @@ func (am *ACMEIssuer) saveAccount(ctx context.Context, ca string, account acme.A
 	return storeTx(ctx, am.config.Storage, all)
 }
 
+// deleteAccountLocally deletes the registration info and private key of the account
+// for the given CA from storage.
+func (am *ACMEIssuer) deleteAccountLocally(ctx context.Context, ca string, account acme.Account) error {
+	primaryContact := getPrimaryContact(account)
+	if err := am.config.Storage.Delete(ctx, am.storageKeyUserReg(ca, primaryContact)); err != nil {
+		return err
+	}
+	return am.config.Storage.Delete(ctx, am.storageKeyUserPrivateKey(ca, primaryContact))
+}
+
 // setEmail does everything it can to obtain an email address
 // from the user within the scope of memory and storage to use
 // for ACME TLS. If it cannot get an email address, it does nothing

--- a/acmeissuer.go
+++ b/acmeissuer.go
@@ -400,6 +400,11 @@ func (am *ACMEIssuer) doIssue(ctx context.Context, csr *x509.CertificateRequest,
 		if err != nil {
 			var prob acme.Problem
 			if errors.As(err, &prob) && prob.Type == acme.ProblemTypeAccountDoesNotExist {
+				am.Logger.Warn("ACME account does not exist on server; attempting to recreate",
+					zap.Strings("account_contact", client.account.Contact),
+					zap.String("account_location", client.account.Location),
+					zap.Object("problem", prob))
+
 				// the account we have no longer exists on the CA, so we need to create a new one;
 				// we could use the same key pair, but this is a good opportunity to rotate keys
 				// (see https://caddy.community/t/acme-account-is-not-regenerated-when-acme-server-gets-reinstalled/22627)


### PR DESCRIPTION
If the CA server got reinstalled or reset, retry with new account credentials.

Obviously this would be a disaster for a public CA, but it's possible that internal PKI gets reset and our client should gracefully try again.

It's a good opportunity to rotate the private key and I also found deleting the old key/reg info to be the easiest way to get CertMagic to try again with new credentials.