### PR TITLE
Demote "storage cleaning happened too recently" from WARN to INFO

### DIFF
--- a/maintain.go
+++ b/maintain.go
@@ -452,7 +452,7 @@ func CleanStorage(ctx context.Context, storage Storage, opts CleanStorageOptions
 			lastTLSClean := lastClean["tls"]
 			if time.Since(lastTLSClean.Timestamp) < opts.Interval {
 				nextTime := time.Now().Add(opts.Interval)
-				opts.Logger.Warn("storage cleaning happened too recently; skipping for now",
+				opts.Logger.Info("storage cleaning happened too recently; skipping for now",
 					zap.String("instance", lastTLSClean.InstanceID),
 					zap.Time("try_again", nextTime),
 					zap.Duration("try_again_in", time.Until(nextTime)),


### PR DESCRIPTION
This isn't an actionable problem, so it doesn't make sense as a WARN.

It shows up in startup logs pretty often if starting and stopping Caddy, slightly annoying.