### PR TITLE
Initial implementation of ARI

### DIFF
--- a/acmeissuer.go
+++ b/acmeissuer.go
@@ -448,6 +448,9 @@ func (am *ACMEIssuer) doIssue(ctx context.Context, csr *x509.CertificateRequest,
 	if am.NotAfter != 0 {
 		params.NotAfter = time.Now().Add(am.NotAfter)
 	}
+	if replacing, ok := ctx.Value(ctxKeyARIReplaces).(*x509.Certificate); ok {
+		params.Replaces = replacing
+	}
 
 	// do this in a loop because there's an error case that may necessitate a retry, but not more than once
 	var certChains []acme.Certificate
@@ -630,6 +633,10 @@ const (
 
 // prefixACME is the storage key prefix used for ACME-specific assets.
 const prefixACME = "acme"
+
+type ctxKey string
+
+const ctxKeyARIReplaces = ctxKey("ari_replaces")
 
 // Interface guards
 var (

--- a/certificates.go
+++ b/certificates.go
@@ -76,7 +76,7 @@ func (cert Certificate) Hash() string { return cert.hash }
 // NeedsRenewal returns true if the certificate is expiring
 // soon (according to ARI and/or cfg) or has expired.
 func (cert Certificate) NeedsRenewal(cfg *Config) bool {
-	return certNeedsRenewal(cfg, cert.Leaf, cert.ari, true)
+	return cfg.certNeedsRenewal(cert.Leaf, cert.ari, true)
 }
 
 // certNeedsRenewal consults ACME Renewal Info (ARI) and certificate expiration to determine
@@ -86,7 +86,7 @@ func (cert Certificate) NeedsRenewal(cfg *Config) bool {
 // first call this to determine if a cert in memory needs renewal, and then right after you
 // call it again to see if the cert in storage still needs renewal -- you probably don't want
 // to log the second time for checking the cert in storage which is mainly for synchronization.
-func certNeedsRenewal(cfg *Config, leaf *x509.Certificate, ari acme.RenewalInfo, emitLogs bool) bool {
+func (cfg *Config) certNeedsRenewal(leaf *x509.Certificate, ari acme.RenewalInfo, emitLogs bool) bool {
 	expiration := expiresAt(leaf)
 
 	var logger *zap.Logger

--- a/certmagic.go
+++ b/certmagic.go
@@ -39,6 +39,7 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net"
@@ -388,7 +389,8 @@ type IssuedCertificate struct {
 	Certificate []byte
 
 	// Any extra information to serialize alongside the
-	// certificate in storage.
+	// certificate in storage. It MUST be serializable
+	// as JSON in order to be preserved.
 	Metadata any
 }
 
@@ -409,7 +411,7 @@ type CertificateResource struct {
 
 	// Any extra information associated with the certificate,
 	// usually provided by the issuer implementation.
-	IssuerData any `json:"issuer_data,omitempty"`
+	IssuerData json.RawMessage `json:"issuer_data,omitempty"`
 
 	// The unique string identifying the issuer of the
 	// certificate; internally useful for storage access.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/caddyserver/zerossl v0.1.2
 	github.com/klauspost/cpuid/v2 v2.2.7
 	github.com/libdns/libdns v0.2.2
-	github.com/mholt/acmez/v2 v2.0.1-0.20240504153930-8e7d337243f5
+	github.com/mholt/acmez/v2 v2.0.1-0.20240506200913-5a16e768dea9
 	github.com/miekg/dns v1.1.58
 	github.com/zeebo/blake3 v0.2.3
 	go.uber.org/zap v1.27.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/caddyserver/zerossl v0.1.2
 	github.com/klauspost/cpuid/v2 v2.2.7
 	github.com/libdns/libdns v0.2.2
-	github.com/mholt/acmez/v2 v2.0.0
+	github.com/mholt/acmez/v2 v2.0.1-0.20240504153930-8e7d337243f5
 	github.com/miekg/dns v1.1.58
 	github.com/zeebo/blake3 v0.2.3
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/klauspost/cpuid/v2 v2.2.7 h1:ZWSB3igEs+d0qvnxR/ZBzXVmxkgt8DdzP6m9pfuV
 github.com/klauspost/cpuid/v2 v2.2.7/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
 github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
-github.com/mholt/acmez/v2 v2.0.0 h1:FsGoEdA5mPhAaGfrwIEM13jnn2hn3jU6Vny+RWypt3o=
-github.com/mholt/acmez/v2 v2.0.0/go.mod h1:fX4c9r5jYwMyMsC+7tkYRxHibkOTgta5DIFGoe67e1U=
+github.com/mholt/acmez/v2 v2.0.1-0.20240504153930-8e7d337243f5 h1:Bx02A3e7Z6q05wh+1yxq9QwcuiWENZcXq33XZq8DWDE=
+github.com/mholt/acmez/v2 v2.0.1-0.20240504153930-8e7d337243f5/go.mod h1:fX4c9r5jYwMyMsC+7tkYRxHibkOTgta5DIFGoe67e1U=
 github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
 github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/klauspost/cpuid/v2 v2.2.7 h1:ZWSB3igEs+d0qvnxR/ZBzXVmxkgt8DdzP6m9pfuV
 github.com/klauspost/cpuid/v2 v2.2.7/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
 github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
-github.com/mholt/acmez/v2 v2.0.1-0.20240504153930-8e7d337243f5 h1:Bx02A3e7Z6q05wh+1yxq9QwcuiWENZcXq33XZq8DWDE=
-github.com/mholt/acmez/v2 v2.0.1-0.20240504153930-8e7d337243f5/go.mod h1:fX4c9r5jYwMyMsC+7tkYRxHibkOTgta5DIFGoe67e1U=
+github.com/mholt/acmez/v2 v2.0.1-0.20240506200913-5a16e768dea9 h1:b8yqT+RDihRjjBRq2FWtnduFHqPlpyrKM4ZH0UatgKM=
+github.com/mholt/acmez/v2 v2.0.1-0.20240506200913-5a16e768dea9/go.mod h1:fX4c9r5jYwMyMsC+7tkYRxHibkOTgta5DIFGoe67e1U=
 github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
 github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/zerosslissuer.go
+++ b/zerosslissuer.go
@@ -258,7 +258,11 @@ func (iss *ZeroSSLIssuer) Revoke(ctx context.Context, cert CertificateResource, 
 	default:
 		return fmt.Errorf("unsupported reason: %d", reason)
 	}
-	return iss.getClient().RevokeCertificate(ctx, cert.IssuerData.(zerossl.CertificateObject).ID, r)
+	var certObj zerossl.CertificateObject
+	if err := json.Unmarshal(cert.IssuerData, &certObj); err != nil {
+		return err
+	}
+	return iss.getClient().RevokeCertificate(ctx, certObj.ID, r)
 }
 
 func (iss *ZeroSSLIssuer) getDistributedValidationInfo(ctx context.Context, identifier string) (acme.Challenge, bool, error) {


### PR DESCRIPTION
Add ARI (ACME Renewal Information) support.

ARI is currently in draft spec and subject to change: https://datatracker.ietf.org/doc/draft-ietf-acme-ari/03/

For certificates issued with ACME, if the ACME server supports it, CertMagic now considers ARI to trigger renewals.

As usual, the maintenance timer keeps certificates renewed, but now we also refresh ARI if it is time to poll again, and we also use ARI as a determining factor for triggering renewal in addition to the expiration date / lifetime. By default, maintenance routines run every 10 minutes so we will likely not miss an ARI change.

We also store ARI along with the certificate and its other metadata. This means that multiple Caddy instances can share the same ARI data. While we don't strictly synchronize the updating of ARI, it is merely an HTTP request, not a whole transaction with strict CA rate limits, so I don't think we need the complexity there. It is theoretically possible that two instances will update ARI at the same time and both write it to storage, but there's really no harm in that.

We conform to ARI spec recommendations and standards, to the best of my knowledge. Thanks to @aarongable for [answering](https://github.com/aarongable/draft-acme-ari/issues/70) [some](https://github.com/aarongable/draft-acme-ari/issues/71) [questions](https://github.com/aarongable/draft-acme-ari/issues/69) there (though one is still open; not urgent though).

We will ignore ARI if a certificate is dangerously close to the end of its lifetime (last 5% currently) to ensure that buggy ARI implementations on either side do not put the site's availability at risk. Once a certificate is extremely close to expiring, we will renew no matter what ARI says.

I'm still testing this change and finishing it up, but I expect it won't be too much longer before it goes out.

TODO:
- [x] Log when ARI window changes
- [x] Better logging to indicate what triggers a renewal (expiration, ARI window, etc)
- [x] On-demand TLS integration