### PR TITLE
Apply DefaultServerName more broadly during handshake

### DIFF
--- a/handshake.go
+++ b/handshake.go
@@ -120,7 +120,7 @@ func (cfg *Config) getCertificateFromCache(hello *tls.ClientHelloInfo) (cert Cer
 			}
 		}
 
-		// fall back to a "default" certificate, if specified
+		// use a "default" certificate by name, if specified
 		if cfg.DefaultServerName != "" {
 			normDefault := normalizedName(cfg.DefaultServerName)
 			cert, defaulted = cfg.selectCert(hello, normDefault)
@@ -823,9 +823,12 @@ func (cfg *Config) getTLSALPNChallengeCert(clientHello *tls.ClientHelloInfo) (*t
 // getNameFromClientHello returns a normalized form of hello.ServerName.
 // If hello.ServerName is empty (i.e. client did not use SNI), then the
 // associated connection's local address is used to extract an IP address.
-func (*Config) getNameFromClientHello(hello *tls.ClientHelloInfo) string {
+func (cfg *Config) getNameFromClientHello(hello *tls.ClientHelloInfo) string {
 	if name := normalizedName(hello.ServerName); name != "" {
 		return name
+	}
+	if cfg.DefaultServerName != "" {
+		return normalizedName(cfg.DefaultServerName)
 	}
 	return localIPFromConn(hello.Conn)
 }


### PR DESCRIPTION
Currently, we only use `DefaultServerName` for choosing a certificate. This doesn't make a lot of sense, because if that is set to a name that doesn't have a cert managed for it, it will not be of much use because we'd use the IP address to fill in an empty ServerName when doing logic, but only using DefaultServerName when loading the certs. So things didn't line up sometimes.

This change makes it so that DefaultServerName will always be used as the ServerName when it was empty, meaning that the IP address will never be used as the "name". This is more expected behavior. (So obviously, if you WANT to serve your IP address over TLS, then don't set DefaultServerName.)

This is being deployed soon to a production environment but is so far working well in staging. Likely to be merged into mainstream CM.