### PR TITLE
downgrade minimum Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caddyserver/certmagic
 
-go 1.22.0
+go 1.21.0
 
 toolchain go1.22.2
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.0
 toolchain go1.22.2
 
 require (
-	github.com/caddyserver/zerossl v0.1.2
+	github.com/caddyserver/zerossl v0.1.3
 	github.com/klauspost/cpuid/v2 v2.2.7
 	github.com/libdns/libdns v0.2.2
 	github.com/mholt/acmez/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/caddyserver/zerossl v0.1.2 h1:tlEu1VzWGoqcCpivs9liKAKhfpJWYJkHEMmlxRbVAxE=
-github.com/caddyserver/zerossl v0.1.2/go.mod h1:wtiJEHbdvunr40ZzhXlnIkOB8Xj4eKtBKizCcZitJiQ=
+github.com/caddyserver/zerossl v0.1.3 h1:onS+pxp3M8HnHpN5MMbOMyNjmTheJyWRaZYwn+YTAyA=
+github.com/caddyserver/zerossl v0.1.3/go.mod h1:CxA0acn7oEGO6//4rtrRjYgEoa4MFw/XofZnrYwGqG4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=


### PR DESCRIPTION
This currently does not work because it requires caddyserver/zerossl#1 to be merged first. That dependency forced this module to upgrade its minimum Go version. That is not needed, and it's causing pains due to mis-synchronization with other parts of Caddy ecosystem. Once caddyserver/zerossl#1 is merged, the dependency here can be updated to use the next patch release of the zerossl package, then do `go mod tidy` and set this PR to be ready.

Depends on caddyserver/zerossl#1