### PR TITLE
Move `looking up info for HTTP validation` to warn level

### DIFF
--- a/httphandlers.go
+++ b/httphandlers.go
@@ -74,7 +74,7 @@ func (am *ACMEIssuer) distributedHTTPChallengeSolver(w http.ResponseWriter, r *h
 	host := hostOnly(r.Host)
 	chalInfo, distributed, err := am.config.getChallengeInfo(r.Context(), host)
 	if err != nil {
-		am.Logger.Error("looking up info for HTTP challenge",
+		am.Logger.Warn("looking up info for HTTP challenge",
 			zap.String("host", host),
 			zap.String("remote_addr", r.RemoteAddr),
 			zap.String("user_agent", r.Header.Get("User-Agent")),
@@ -165,7 +165,7 @@ func (iss *ZeroSSLIssuer) distributedHTTPValidationAnswer(w http.ResponseWriter,
 	host := hostOnly(r.Host)
 	valInfo, distributed, err := iss.getDistributedValidationInfo(r.Context(), host)
 	if err != nil {
-		logger.Error("looking up info for HTTP validation",
+		logger.Warn("looking up info for HTTP validation",
 			zap.String("host", host),
 			zap.String("remote_addr", r.RemoteAddr),
 			zap.String("user_agent", r.Header.Get("User-Agent")),


### PR DESCRIPTION
This PR moves `looking up info for HTTP {challenge,validation}` from an error to a warning level.

The reasoning for this is as follows: we see with our certmagic deploy that the `.well-known/acme-challenge/xxx` paths are automatically checked by old issuers that still think they are managing the domain. These acme-challenge paths are then checked by certmagic to solve the challenge, but as it's an unknown challenge token, this fails.

It's still a relevant message to log, although not at the error level, IMHO.

Fixes https://github.com/caddyserver/certmagic/issues/268