### PR TITLE
Sync ACME account registration

### DIFF
--- a/account.go
+++ b/account.go
@@ -415,6 +415,15 @@ func (am *ACMEIssuer) mostRecentAccountEmail(ctx context.Context, caURL string) 
 	return getPrimaryContact(account), true
 }
 
+func accountRegLockKey(acc acme.Account) string {
+	key := "register_acme_account"
+	if len(acc.Contact) == 0 {
+		return key
+	}
+	key += "_" + getPrimaryContact(acc)
+	return key
+}
+
 // getPrimaryContact returns the first contact on the account (if any)
 // without the scheme. (I guess we assume an email address.)
 func getPrimaryContact(account acme.Account) string {


### PR DESCRIPTION
This implements a distributed lock around registering new ACME accounts. I am not sure why this issue hasn't really appeared before, whether a recent change exposed this bug that we've always had, or we recently introduced this bug:

https://caddy.community/t/lets-encrypt-hits-rate-limit-too-many-registrations-for-this-ip/24343

Hoping this will tame things a bit. Makes sense in my head.