### PR TITLE
Add .internal to internal-only hostnames

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -552,6 +552,7 @@ func SubjectIsInternal(subj string) bool {
 	return subj == "localhost" ||
 		strings.HasSuffix(subj, ".localhost") ||
 		strings.HasSuffix(subj, ".local") ||
+		strings.HasSuffix(subj, ".internal") ||
 		strings.HasSuffix(subj, ".home.arpa") ||
 		isInternalIP(subj)
 }

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -163,6 +163,8 @@ func TestSubjectQualifiesForPublicCert(t *testing.T) {
 		{"local", true},
 		{"foo.local", false},
 		{"foo.bar.local", false},
+		{"foo.internal", false},
+		{"foo.bar.internal", false},
 		{"foo.home.arpa", false},
 		{"foo.bar.home.arpa", false},
 		{"192.168.1.3", false},


### PR DESCRIPTION
ICANN is in the progress of reserving `.internal` for private use (see [this closed consultation](https://www.icann.org/en/public-comment/proceeding/proposed-top-level-domain-string-for-private-use-24-01-2024)). As such I believe that this TLD would be a suitable addition to the list of internal addresses used in `SubjectIsInternal`.

I based this PR on 6668587 which added `.home.arpa` to the list.