### PR TITLE
Repair broken link for dotGo presentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,9 +579,9 @@ Caddy was also the first to sport "on-demand" issuance technology, which obtains
 
 Consequently, CertMagic brings all these (and more) features and capabilities right into your own Go programs.
 
-You can [watch a 2016 dotGo talk](https://www.dotconferences.com/2016/10/matthew-holt-go-with-acme) by the author of this library about using ACME to automate certificate management in Go programs:
+You can [watch a 2016 dotGo talk](https://youtu.be/KdX51QJWQTA) by the author of this library about using ACME to automate certificate management in Go programs:
 
-[![Matthew Holt speaking at dotGo 2016 about ACME in Go](https://user-images.githubusercontent.com/1128849/49921557-2d506780-fe6b-11e8-97bf-6053b6b4eb48.png)](https://www.dotconferences.com/2016/10/matthew-holt-go-with-acme)
+[![Matthew Holt speaking at dotGo 2016 about ACME in Go](https://user-images.githubusercontent.com/1128849/49921557-2d506780-fe6b-11e8-97bf-6053b6b4eb48.png)](https://youtu.be/KdX51QJWQTA)
 
 
 


### PR DESCRIPTION
All of dotGo's videos have been transferred to YouTube.