### PR TITLE
ZeroSSLIssuer: Make PollInterval configurable

### DIFF
--- a/zerosslissuer.go
+++ b/zerosslissuer.go
@@ -62,6 +62,9 @@ type ZeroSSLIssuer struct {
 	// validation, set this field.
 	CNAMEValidation *DNSManager
 
+	// Delay between poll attempts.
+	PollInterval time.Duration
+
 	// An optional (but highly recommended) logger.
 	Logger *zap.Logger
 }
@@ -203,8 +206,8 @@ func (iss *ZeroSSLIssuer) Issue(ctx context.Context, csr *x509.CertificateReques
 	}, nil
 }
 
-func (*ZeroSSLIssuer) waitForCertToBeIssued(ctx context.Context, client zerossl.Client, cert zerossl.CertificateObject) (zerossl.CertificateObject, error) {
-	ticker := time.NewTicker(5 * time.Second)
+func (iss *ZeroSSLIssuer) waitForCertToBeIssued(ctx context.Context, client zerossl.Client, cert zerossl.CertificateObject) (zerossl.CertificateObject, error) {
+	ticker := time.NewTicker(iss.pollInterval())
 	defer ticker.Stop()
 
 	for {
@@ -225,6 +228,13 @@ func (*ZeroSSLIssuer) waitForCertToBeIssued(ctx context.Context, client zerossl.
 			}
 		}
 	}
+}
+
+func (iss *ZeroSSLIssuer) pollInterval() time.Duration {
+	if iss.PollInterval == 0 {
+		return defaultPollInterval
+	}
+	return iss.PollInterval
 }
 
 func (iss *ZeroSSLIssuer) getClient() zerossl.Client {
@@ -302,6 +312,7 @@ const (
 	zerosslAPIBase              = "https://" + zerossl.BaseURL + "/acme"
 	zerosslValidationPathPrefix = "/.well-known/pki-validation/"
 	zerosslIssuerKey            = "zerossl"
+	defaultPollInterval         = 5 * time.Second
 )
 
 // Interface guards


### PR DESCRIPTION
This PR adds the `PollInterval` option to the `ZeroSSLIssuer`, which lets users adjust the polling interval for certificate retrieval when using the ZeroSSL issuer.

If no `PollInterval` is configured (or a value of `0` is set), the default poll interval of 5 seconds is used.
