### PR TITLE
Quiet OCSP warnings if the cert has a short lifetime

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -193,7 +193,7 @@ func (cert Certificate) Lifetime() time.Duration {
 	if cert.Leaf == nil || cert.Leaf.NotAfter.IsZero() {
 		return 0
 	}
-	return cert.Leaf.NotAfter.Sub(expiresAt(cert.Leaf))
+	return expiresAt(cert.Leaf).Sub(cert.Leaf.NotBefore)
 }
 
 // currentlyInRenewalWindow returns true if the current time is within

--- a/certificates.go
+++ b/certificates.go
@@ -338,12 +338,7 @@ func (cfg *Config) CacheUnmanagedTLSCertificate(ctx context.Context, tlsCert tls
 	}
 	err = stapleOCSP(ctx, cfg.OCSP, cfg.Storage, &cert, nil)
 	if err != nil {
-		// If the certificate's lifetime is less than a week, then
-		// it's a short-validity cert and we can ignore not having
-		// OCSP. Revocation of short certs is mostly pointless.
-		if cert.Lifetime() > 7*24*time.Hour {
-			cfg.Logger.Warn("stapling OCSP", zap.Error(err))
-		}
+		cfg.Logger.Warn("stapling OCSP", zap.Error(err))
 	}
 	cfg.emit(ctx, "cached_unmanaged_cert", map[string]any{"sans": cert.Names})
 	cert.Tags = tags
@@ -392,12 +387,7 @@ func (cfg Config) makeCertificateWithOCSP(ctx context.Context, certPEMBlock, key
 	}
 	err = stapleOCSP(ctx, cfg.OCSP, cfg.Storage, &cert, certPEMBlock)
 	if err != nil {
-		// If the certificate's lifetime is less than a week, then
-		// it's a short-validity cert and we can ignore not having
-		// OCSP. Revocation of short certs is mostly pointless.
-		if cert.Lifetime() > 7*24*time.Hour {
-			cfg.Logger.Warn("stapling OCSP", zap.Error(err), zap.Strings("identifiers", cert.Names))
-		}
+		cfg.Logger.Warn("stapling OCSP", zap.Error(err), zap.Strings("identifiers", cert.Names))
 	}
 	return cert, nil
 }

--- a/handshake.go
+++ b/handshake.go
@@ -568,17 +568,12 @@ func (cfg *Config) handshakeMaintenance(ctx context.Context, hello *tls.ClientHe
 
 		err := stapleOCSP(ctx, cfg.OCSP, cfg.Storage, &cert, nil)
 		if err != nil {
-			// If the certificate's lifetime is less than a week, then
-			// it's a short-validity cert and we can ignore not having
-			// OCSP. Revocation of short certs is mostly pointless.
-			if cert.Lifetime() > 7*24*time.Hour {
-				// An error with OCSP stapling is not the end of the world, and in fact, is
-				// quite common considering not all certs have issuer URLs that support it.
-				logger.Warn("stapling OCSP",
-					zap.String("server_name", hello.ServerName),
-					zap.Strings("sans", cert.Names),
-					zap.Error(err))
-			}
+			// An error with OCSP stapling is not the end of the world, and in fact, is
+			// quite common considering not all certs have issuer URLs that support it.
+			logger.Warn("stapling OCSP",
+				zap.String("server_name", hello.ServerName),
+				zap.Strings("sans", cert.Names),
+				zap.Error(err))
 		} else {
 			logger.Debug("successfully stapled new OCSP response",
 				zap.Strings("identifiers", cert.Names),

--- a/ocsp.go
+++ b/ocsp.go
@@ -98,7 +98,7 @@ func stapleOCSP(ctx context.Context, ocspConfig OCSPConfig, storage Storage, cer
 		if ocspErr != nil {
 			// For short-lived certificates, this is fine and we can ignore
 			// logging because OCSP doesn't make much sense for them anyway.
-			if cert.Lifetime() > 7*24*time.Hour {
+			if cert.Lifetime() < 7*24*time.Hour {
 				return nil
 			}
 			// There's nothing else we can do to get OCSP for this certificate,

--- a/ocsp.go
+++ b/ocsp.go
@@ -93,11 +93,16 @@ func stapleOCSP(ctx context.Context, ocspConfig OCSPConfig, storage Storage, cer
 	// then we need to request it from the OCSP responder
 	if ocspResp == nil || len(ocspBytes) == 0 {
 		ocspBytes, ocspResp, ocspErr = getOCSPForCert(ocspConfig, pemBundle)
+		// An error here is not a problem because a certificate
+		// may simply not contain a link to an OCSP server.
 		if ocspErr != nil {
-			// An error here is not a problem because a certificate may simply
-			// not contain a link to an OCSP server. But we should log it anyway.
+			// For short-lived certificates, this is fine and we can ignore
+			// logging because OCSP doesn't make much sense for them anyway.
+			if cert.Lifetime() > 7*24*time.Hour {
+				return nil
+			}
 			// There's nothing else we can do to get OCSP for this certificate,
-			// so we can return here with the error.
+			// so we can return here with the error to warn about it.
 			return fmt.Errorf("no OCSP stapling for %v: %w", cert.Names, ocspErr)
 		}
 		gotNewOCSP = true


### PR DESCRIPTION
In Caddy, we often get warnings like these when using internally issued certs:

```
{"level":"warn","ts":1731027618.3063543,"logger":"tls","msg":"stapling OCSP","error":"no OCSP stapling for [localhost]: no OCSP server specified in certificate","identifiers":["localhost"]}
```

These generally have a very short lifetime and for that reason warning about them not having OCSP configured is just noise, because OCSP on short certs isn't too useful.

I added a `Lifetime()` method to help here, I used `expiresAt` for the "1s resolution of ASN.1 UTCTime/GeneralizedTime", hope that's correct.