### PR TITLE
Replace interface{} with any

### DIFF
--- a/account_test.go
+++ b/account_test.go
@@ -145,10 +145,10 @@ func (r *recordingStorage) Unlock(ctx context.Context, name string) error {
 
 type recordedCall struct {
 	name string
-	args []interface{}
+	args []any
 }
 
-func (r *recordingStorage) record(name string, args ...interface{}) {
+func (r *recordingStorage) record(name string, args ...any) {
 	r.calls = append(r.calls, recordedCall{name: name, args: args})
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -64,7 +64,7 @@ func Failnow(t testing.TB, xs string, msgs ...string) {
 	t.FailNow()
 }
 
-func ObjectsAreEqual(expected, actual interface{}) bool {
+func ObjectsAreEqual(expected, actual any) bool {
 	if expected == nil || actual == nil {
 		return expected == actual
 	}
@@ -84,7 +84,7 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 	return bytes.Equal(exp, act)
 }
 
-func ObjectsAreEqualValues(expected, actual interface{}) bool {
+func ObjectsAreEqualValues(expected, actual any) bool {
 	if ObjectsAreEqual(expected, actual) {
 		return true
 	}


### PR DESCRIPTION
This PR replaces a few occurrences of `interface{}` with newer `any` syntax.