### PR TITLE
ari: Only check if cert is not expired, and use proper context

### DIFF
--- a/maintain.go
+++ b/maintain.go
@@ -523,8 +523,7 @@ func (cfg *Config) updateARI(ctx context.Context, cert Certificate, logger *zap.
 
 	// of the issuers configured, hopefully one of them is the ACME CA we got the cert from
 	for _, iss := range cfg.Issuers {
-		ariGetter, ok := iss.(RenewalInfoGetter)
-		if ok && iss.IssuerKey() == cert.issuerKey {
+		if ariGetter, ok := iss.(RenewalInfoGetter); ok && iss.IssuerKey() == cert.issuerKey {
 			newARI, err = ariGetter.GetRenewalInfo(ctx, cert) // be sure to use existing newARI variable so we can compare against old value in the defer
 			if err != nil {
 				// could be anything, but a common error might simply be the "wrong" ACME CA

--- a/maintain.go
+++ b/maintain.go
@@ -527,6 +527,7 @@ func (cfg *Config) updateARI(ctx context.Context, cert Certificate, logger *zap.
 		logger.Debug("iterating issuer for ARI update",
 			zap.String("issuer_key", iss.IssuerKey()),
 			zap.String("looking_for", cert.issuerKey),
+			zap.String("issuer_type", fmt.Sprintf("%T", iss)),
 			zap.Bool("supports_ari", ok))
 		if ok && iss.IssuerKey() == cert.issuerKey {
 			newARI, err = ariGetter.GetRenewalInfo(ctx, cert) // be sure to use existing newARI variable so we can compare against old value in the defer

--- a/maintain.go
+++ b/maintain.go
@@ -523,7 +523,12 @@ func (cfg *Config) updateARI(ctx context.Context, cert Certificate, logger *zap.
 
 	// of the issuers configured, hopefully one of them is the ACME CA we got the cert from
 	for _, iss := range cfg.Issuers {
-		if ariGetter, ok := iss.(RenewalInfoGetter); ok && iss.IssuerKey() == cert.issuerKey {
+		ariGetter, ok := iss.(RenewalInfoGetter)
+		logger.Debug("iterating issuer for ARI update",
+			zap.String("issuer_key", iss.IssuerKey()),
+			zap.String("looking_for", cert.issuerKey),
+			zap.Bool("supports_ari", ok))
+		if ok && iss.IssuerKey() == cert.issuerKey {
 			newARI, err = ariGetter.GetRenewalInfo(ctx, cert) // be sure to use existing newARI variable so we can compare against old value in the defer
 			if err != nil {
 				// could be anything, but a common error might simply be the "wrong" ACME CA

--- a/maintain.go
+++ b/maintain.go
@@ -524,11 +524,6 @@ func (cfg *Config) updateARI(ctx context.Context, cert Certificate, logger *zap.
 	// of the issuers configured, hopefully one of them is the ACME CA we got the cert from
 	for _, iss := range cfg.Issuers {
 		ariGetter, ok := iss.(RenewalInfoGetter)
-		logger.Debug("iterating issuer for ARI update",
-			zap.String("issuer_key", iss.IssuerKey()),
-			zap.String("looking_for", cert.issuerKey),
-			zap.String("issuer_type", fmt.Sprintf("%T", iss)),
-			zap.Bool("supports_ari", ok))
 		if ok && iss.IssuerKey() == cert.issuerKey {
 			newARI, err = ariGetter.GetRenewalInfo(ctx, cert) // be sure to use existing newARI variable so we can compare against old value in the defer
 			if err != nil {


### PR DESCRIPTION
Using a context that expires after the handshake cancels, for a background task, is no good!

Also avoid unnecessary ARI maintenance, if cert is expired, it'll try to be renewed regardless.