### PR TITLE
Move cfg nil check from RenewManagedCertificates to getConfig

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -365,6 +365,10 @@ func (certCache *Cache) getConfig(cert Certificate) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	if cfg == nil {
+		// this is bad if this happens, probably a programmer error (oops)
+		return nil, fmt.Errorf("no configuration associated with certificate: %v;", cert.Names)
+	}
 	if cfg.certCache == nil {
 		return nil, fmt.Errorf("config returned for certificate %v has nil cache; expected %p (this one)",
 			cert.Names, certCache)

--- a/maintain.go
+++ b/maintain.go
@@ -125,12 +125,6 @@ func (certCache *Cache) RenewManagedCertificates(ctx context.Context) error {
 				zap.Error(err))
 			continue
 		}
-		if cfg == nil {
-			// this is bad if this happens, probably a programmer error (oops)
-			log.Error("no configuration associated with certificate; unable to manage",
-				zap.Strings("identifiers", cert.Names))
-			continue
-		}
 		if cfg.OnDemand != nil {
 			continue
 		}


### PR DESCRIPTION
getConfig checks cfg.certCache so cfg can never be nil inside of getConfig or it can crash with:
 invalid memory address or nil pointer dereference