### PR TITLE
Fix HTTP-01 challenge for IPv6 literal addresses

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -651,6 +651,9 @@ func isInternalIP(addr string) bool {
 func hostOnly(hostport string) string {
 	host, _, err := net.SplitHostPort(hostport)
 	if err != nil {
+		if len(hostport) > 2 && hostport[0] == '[' && hostport[len(hostport)-1] == ']' {
+			return hostport[1 : len(hostport)-1]
+		}
 		return hostport // OK; probably had no port to begin with
 	}
 	return host


### PR DESCRIPTION
## What changed

Strip square brackets from bare IPv6 literals in `hostOnly()` when `net.SplitHostPort` returns an error.

## Why

For HTTP-01 validation against an IPv6 literal, the CA sends a `Host` header like `[2001:db8::1]` without a port.

`hostOnly()` returns that bracketed value, while `challenge.Identifier.Value` holds the bare IPv6 address, so the host check fails.

## Validation

- `go test ./...`
