### PR TITLE
Support listening on file descriptors

### DIFF
--- a/internal/filedescriptor/filedescriptor_other.go
+++ b/internal/filedescriptor/filedescriptor_other.go
@@ -1,0 +1,11 @@
+//go:build !unix
+
+package filedescriptor
+
+import "fmt"
+
+var IsUnix = false
+
+func Dup(fd int) (int, error) {
+	return 0, fmt.Errorf("File descriptor duplication is not supported on this platform")
+}

--- a/internal/filedescriptor/filedescriptor_unix.go
+++ b/internal/filedescriptor/filedescriptor_unix.go
@@ -1,0 +1,13 @@
+//go:build unix
+
+package filedescriptor
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+var IsUnix = true
+
+func Dup(fd int) (int, error) {
+	return unix.Dup(fd)
+}

--- a/solvers.go
+++ b/solvers.go
@@ -22,13 +22,16 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"path"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/caddyserver/certmagic/internal/filedescriptor"
 	"github.com/libdns/libdns"
 	"github.com/mholt/acmez/v3"
 	"github.com/mholt/acmez/v3/acme"
@@ -708,6 +711,7 @@ func getSolverInfo(address string) *solverInfo {
 // which is useful for our challenge servers, where we assume
 // that whatever is already listening can solve the challenges.
 func robustTryListen(addr string) (net.Listener, error) {
+
 	var listenErr error
 	for i := 0; i < 2; i++ {
 		// doesn't hurt to sleep briefly before the second
@@ -718,17 +722,56 @@ func robustTryListen(addr string) (net.Listener, error) {
 
 		// if we can bind the socket right away, great!
 		var ln net.Listener
-		ln, listenErr = net.Listen("tcp", addr)
-		if listenErr == nil {
-			return ln, nil
-		}
 
-		// if it failed just because the socket is already in use, we
-		// have no choice but to assume that whatever is using the socket
-		// can answer the challenge already, so we ignore the error
-		connectErr := dialTCPSocket(addr)
-		if connectErr == nil {
-			return nil, nil
+		// First, try to parse the address as a file descriptor. When testing
+		// with Caddy, the address contains a port number (even though that
+		// doesn't really make sense for a file descriptor), so remove that too.
+		fd, err := strconv.ParseUint(strings.Split(strings.TrimPrefix(addr, "fd/"), ":")[0], 0, strconv.IntSize)
+		if err == nil {
+			// os.NewFile takes ownership of the file descriptor, so if
+			// something else is using the file descriptor, this would be bad
+			// since it means that closing the os.File would also close the
+			// underlying file descriptor out from under the other user. So
+			// instead we'll duplicate the file descriptor here, then we can
+			// safely do whatever we want with it.
+			fd, listenErr := filedescriptor.Dup(int(fd))
+			if listenErr != nil {
+				continue
+			}
+
+			// net.FileListener internally duplicates the file descriptor, so we
+			// can unconditionally close the "file" after creating the listener.
+			file := os.NewFile(uintptr(fd), addr)
+			defer file.Close()
+
+			// net.FileListener will return an error if the file descriptor is
+			// not a stream socket, so we don't need to check ourselves. But the
+			// socket could be a Unix socket, so we still need to check for that
+			// and raise an error if so.
+			ln, listenErr = net.FileListener(file)
+			if listenErr == nil {
+				return ln, nil
+			}
+
+			if ln.Addr().Network() != "tcp" {
+				ln.Close()
+				return nil, fmt.Errorf("file descriptor %d is not a TCP socket", fd)
+			}
+
+			return ln, nil
+		} else {
+			ln, listenErr = net.Listen("tcp", addr)
+			if listenErr == nil {
+				return ln, nil
+			}
+
+			// if it failed just because the socket is already in use, we
+			// have no choice but to assume that whatever is using the socket
+			// can answer the challenge already, so we ignore the error
+			connectErr := dialTCPSocket(addr)
+			if connectErr == nil {
+				return nil, nil
+			}
 		}
 
 		// Hmm, we couldn't connect to the socket, so something else must

--- a/solvers_test.go
+++ b/solvers_test.go
@@ -15,8 +15,11 @@
 package certmagic
 
 import (
+	"net"
+	"strconv"
 	"testing"
 
+	"github.com/caddyserver/certmagic/internal/filedescriptor"
 	"github.com/mholt/acmez/v3/acme"
 )
 
@@ -175,5 +178,54 @@ func TestGetACMEChallenge_IPv6Brackets(t *testing.T) {
 	// Lookup with bare IPv6 should still work.
 	if _, ok := GetACMEChallenge("::1"); !ok {
 		t.Error("GetACMEChallenge(\"::1\") should find challenge stored under \"::1\"")
+	}
+}
+
+func TestTryListen(t *testing.T) {
+	// Make sure that a regular TCP address still works.
+	regularLn, err := robustTryListen("127.0.0.1:8080")
+	if err != nil {
+		t.Fatalf("robustTryListen with regular address: %v", err)
+	}
+	regularLn.Close()
+
+	// The rest of the tests only make sense on Unix-like systems
+	if !filedescriptor.IsUnix {
+		t.Skip("file descriptor tests only work on Unix-like systems")
+	}
+
+	// Create a new file descriptor containing a TCP listening socket
+	fdLn, err := net.Listen("tcp", "127.0.0.1:8080")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer fdLn.Close()
+
+	// Get the pseudo-address of the file descriptor.
+	fd, err := fdLn.(*net.TCPListener).File()
+	if err != nil {
+		t.Fatalf("TCPListener.File: %v", err)
+	}
+	correctName := "fd/" + strconv.FormatUint(uint64(fd.Fd()), 10)
+
+	// Make sure that we can listen on the file descriptor.
+	correctLn, err := robustTryListen(correctName)
+	if err != nil {
+		t.Fatalf("robustTryListen: %v", err)
+	}
+	correctLn.Close()
+
+	// Make sure that it still works when we add a port number.
+	correctLn, err = robustTryListen(correctName + ":80")
+	if err != nil {
+		t.Fatalf("robustTryListen with port: %v", err)
+	}
+	correctLn.Close()
+
+	// Make up a fake file descriptor that shouldn't exist.
+	fakeName := "fd/123456"
+	_, err = robustTryListen(fakeName)
+	if err == nil {
+		t.Fatalf("robustTryListen(%q) should have failed", fakeName)
 	}
 }


### PR DESCRIPTION
Fixes caddyserver/caddy#7525.

I've tested this with the following `Caddyfile`

```caddyfile
{
	debug

	servers {
		trace
	}

	acme_ca https://acme-staging-v02.api.letsencrypt.org/directory

	auto_https disable_redirects
	default_bind fd/4 {
		protocols h1 h2
	}
}

http:// {
	bind fd/3
	redir https://{host}{uri} permanent
}

testing.958386.xyz { # Replace with your own domain
	log {
		level DEBUG
		format console
	}

	respond "Hello, world!"
}
```

by running the following command:

```console
$ xcaddy build master --with=github.com/caddyserver/certmagic=.
$ systemd-socket-activate --now --listen=0.0.0.0:80 --listen=0.0.0.0:443 ./caddy run --config=./Caddyfile
```

I confirmed that

1. I could not get a certificate without this commit.
2. With this commit applied, I could get a freshly-issued certificate, and Caddy served it properly.
3. I could still get fresh certificates in the regular non-socket-activation case.
4. The tests I added all pass.

I've only tested this on Linux x86_64, but other platforms should _hopefully_ be fine. The `Dup` code is fairly ugly, and I'm not 100% sure if it's necessary or not, but I know that closing someone else's file descriptors is a bad idea, so I added it just to be safe.