### PR TITLE
Fix jm.names and jm.activeWorkees leak

### DIFF
--- a/async.go
+++ b/async.go
@@ -58,26 +58,40 @@ func (jm *jobManager) worker() {
 			buf = buf[:runtime.Stack(buf, false)]
 			log.Printf("panic: certificate worker: %v\n%s", err, buf)
 		}
+		// Decrement activeWorkers here (rather than inline at the
+		// queue-empty branch) so that the counter is correctly released
+		// even when the worker exits via a recovered panic. Otherwise the
+		// counter drifts upward and eventually no new workers ever spawn.
+		jm.mu.Lock()
+		jm.activeWorkers--
+		jm.mu.Unlock()
 	}()
 
 	for {
 		jm.mu.Lock()
 		if len(jm.queue) == 0 {
-			jm.activeWorkers--
 			jm.mu.Unlock()
 			return
 		}
 		next := jm.queue[0]
 		jm.queue = jm.queue[1:]
 		jm.mu.Unlock()
-		if err := next.job(); err != nil {
-			next.logger.Error("job failed", zap.Error(err))
-		}
-		if next.name != "" {
-			jm.mu.Lock()
-			delete(jm.names, next.name)
-			jm.mu.Unlock()
-		}
+		// Run the job inside a closure so that the name is always removed
+		// from jm.names, even if the job panics. Otherwise the name would
+		// stay in the in-flight set and future Submit() calls for the same
+		// name would be silently dropped until process restart.
+		func() {
+			defer func() {
+				if next.name != "" {
+					jm.mu.Lock()
+					delete(jm.names, next.name)
+					jm.mu.Unlock()
+				}
+			}()
+			if err := next.job(); err != nil {
+				next.logger.Error("job failed", zap.Error(err))
+			}
+		}()
 	}
 }
 

--- a/async_test.go
+++ b/async_test.go
@@ -1,0 +1,71 @@
+package certmagic
+
+import (
+	"io"
+	stdlog "log"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// TestJobManagerCleansUpAfterJobPanic verifies that when a submitted job
+// panics, the worker still releases the in-flight name and decrements its
+// active-worker counter. Without these cleanups, a single panic would
+// silently strand all future renewals for that name (and, after enough
+// panics, every name) until process restart. See certmagic issue for
+// caddyserver/caddy#7366.
+func TestJobManagerCleansUpAfterJobPanic(t *testing.T) {
+	// Suppress the worker's "panic: certificate worker: ..." message so it
+	// doesn't pollute test output. We're intentionally triggering a panic.
+	stdlog.SetOutput(io.Discard)
+	t.Cleanup(func() { stdlog.SetOutput(io.Discard) })
+
+	jm := &jobManager{maxConcurrentJobs: 10}
+	logger := zap.NewNop()
+
+	jm.Submit(logger, "renewal_X", func() error {
+		panic("simulated panic from acme library")
+	})
+
+	// Cleanup happens in deferred handlers inside worker(), so we cannot
+	// synchronize on it from inside the job itself. Poll until state settles.
+	if !waitUntil(time.Second, func() bool {
+		jm.mu.Lock()
+		defer jm.mu.Unlock()
+		_, nameStillTracked := jm.names["renewal_X"]
+		return !nameStillTracked && jm.activeWorkers == 0
+	}) {
+		jm.mu.Lock()
+		_, nameStillTracked := jm.names["renewal_X"]
+		active := jm.activeWorkers
+		jm.mu.Unlock()
+		t.Fatalf("worker did not clean up after panic: name still tracked=%v, activeWorkers=%d (want false, 0)",
+			nameStillTracked, active)
+	}
+
+	// A subsequent submission with the same name must actually run.
+	// If the names leak regressed, this Submit would be silently dropped.
+	var ran int32
+	jm.Submit(logger, "renewal_X", func() error {
+		atomic.StoreInt32(&ran, 1)
+		return nil
+	})
+	if !waitUntil(time.Second, func() bool {
+		return atomic.LoadInt32(&ran) == 1
+	}) {
+		t.Fatal("second Submit with the same name was silently dropped after panic")
+	}
+}
+
+func waitUntil(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return cond()
+}


### PR DESCRIPTION
In my investigation of the caddy’s issue.
https://github.com/caddyserver/caddy/issues/7366

I found potential resoure leaks in jobmanager.worker if the next.Job causes panic, jm.names is not deleted, activeWorker counter is not decremented.