### PR TITLE
storage: mark cluster-sensitive reads for caching backends

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -531,7 +531,9 @@ func fillCertFromLeaf(cert *Certificate, tlsCert tls.Certificate) error {
 // meantime, and it would be a good idea to simply load the cert
 // into our cache rather than repeating the renewal process again.
 func (cfg *Config) managedCertInStorageNeedsRenewal(ctx context.Context, cert Certificate) (bool, error) {
-	certRes, err := cfg.loadCertResourceAnyIssuer(ctx, cert.Names[0])
+	// Must observe shared durable storage, not a local cache, so another
+	// instance's renewal is visible and we reload instead of re-issuing.
+	certRes, err := cfg.loadCertResourceAnyIssuer(WithStrongStorageConsistency(ctx), cert.Names[0])
 	if err != nil {
 		return false, err
 	}
@@ -546,7 +548,9 @@ func (cfg *Config) managedCertInStorageNeedsRenewal(ctx context.Context, cert Ce
 // already in storage. It returns the newly-loaded certificate if successful.
 func (cfg *Config) reloadManagedCertificate(ctx context.Context, oldCert Certificate) (Certificate, error) {
 	cfg.Logger.Info("reloading managed certificate", zap.Strings("identifiers", oldCert.Names))
-	newCert, err := cfg.loadManagedCertificate(ctx, oldCert.Names[0])
+	// Intentionally refreshing from durable shared storage (e.g. after a
+	// peer renewed); bypass local storage caches.
+	newCert, err := cfg.loadManagedCertificate(WithStrongStorageConsistency(ctx), oldCert.Names[0])
 	if err != nil {
 		return Certificate{}, fmt.Errorf("loading managed certificate for %v from storage: %v", oldCert.Names, err)
 	}

--- a/config.go
+++ b/config.go
@@ -553,6 +553,10 @@ func (cfg *Config) obtainCert(ctx context.Context, name string, interactive bool
 
 	name = cfg.transformSubject(ctx, log, name)
 
+	// Existence checks and post-lock re-checks must see shared durable
+	// storage so a peer's obtain is visible (caching Storage backends).
+	ctx = WithStrongStorageConsistency(ctx)
+
 	// if storage has all resources for this certificate, obtain is a no-op
 	if cfg.storageHasCertResourcesAnyIssuer(ctx, name) {
 		return nil
@@ -824,6 +828,10 @@ func (cfg *Config) renewCert(ctx context.Context, name string, force, interactiv
 	log := cfg.Logger.Named("renew")
 
 	name = cfg.transformSubject(ctx, log, name)
+
+	// Loads under the issue lock (already-renewed check) must see shared
+	// durable storage, not a stale local cache.
+	ctx = WithStrongStorageConsistency(ctx)
 
 	// ensure storage is writeable and readable
 	// TODO: this is not necessary every time; should only perform check once every so often for each storage, which may require some global state...

--- a/storage.go
+++ b/storage.go
@@ -57,6 +57,18 @@ import (
 // key, and concurrent calls to Store() should not corrupt a
 // file.
 //
+// Caching or tiered Storage implementations (for example a
+// local disk cache in front of shared remote storage) SHOULD
+// honor StrongStorageConsistency when set on the context
+// passed to Load, Exists, Stat, and List: bypass local caches
+// and read through to durable shared storage so cluster
+// coordination (renewal pre-checks, obtain/renew under lock,
+// reload-from-storage) observes the same data on every instance.
+// Store should always write through to durable storage.
+// Contexts without StrongStorageConsistency may be served from
+// a local cache. Plain backends such as FileStorage may ignore
+// the flag.
+//
 // For simplicity, this is not a streaming API and is not
 // suitable for very large files.
 type Storage interface {
@@ -352,6 +364,27 @@ var locksMu sync.Mutex
 // for most cases. Only use this if you need to
 // directly access TLS assets in your application.
 var StorageKeys KeyBuilder
+
+type strongStorageConsistencyCtxKey struct{}
+
+// WithStrongStorageConsistency returns a child context that asks
+// caching Storage backends to bypass local caches and read through
+// to durable shared storage. CertMagic sets this on contexts used
+// for cluster-sensitive reads (renewal pre-checks, obtain/renew
+// decisions under lock, and reload-from-storage). Handshake-path
+// loads that may be served from a local cache do not set it.
+//
+// Non-caching Storage implementations may ignore this value.
+func WithStrongStorageConsistency(ctx context.Context) context.Context {
+	return context.WithValue(ctx, strongStorageConsistencyCtxKey{}, true)
+}
+
+// StrongStorageConsistency reports whether ctx was marked with
+// WithStrongStorageConsistency.
+func StrongStorageConsistency(ctx context.Context) bool {
+	v, _ := ctx.Value(strongStorageConsistencyCtxKey{}).(bool)
+	return v
+}
 
 const (
 	prefixCerts = "certificates"


### PR DESCRIPTION
## Why

We run many edge instances that terminate TLS with CertMagic against a **shared remote Storage**, and want a **local disk (or similar) cache** in front of it so handshake `Load`s do not pay remote latency on every in-memory cache miss.

That breaks multi-instance renew coordination today: the renew **pre-check** (`managedCertInStorageNeedsRenewal`) and related loads use the same `Load` path. If they hit a stale local cache, peers queue unnecessary renewals (issue-lock storms) instead of taking the cheap reload-from-storage path—even though shared storage already has the new cert.

Handshake can tolerate a slightly stale-but-valid cert. Cluster decisions (already renewed? already obtained?) cannot.

## What

- `WithStrongStorageConsistency` / `StrongStorageConsistency` on `context`
- Set on renew pre-check, reload-from-storage, obtain, and renew
- Handshake / normal managed loads unchanged
- Non-caching backends ignore the flag (no behavior change)
- Caching backends SHOULD read through to durable storage when the flag is set; `Store` should always write through

## Other approaches considered

- **Optional `LoadConsistent` / `ExistsConsistent` interface** (like `LockLeaseRenewer`): more explicit, also non-breaking; happy to switch if preferred over context.
- **Scoped `Consistent(fn)` mode on Storage**: possible, but easy to get wrong under concurrent `Load`s.
- **Changing `Storage.Load` signatures**: breaking for all implementers.
- **External invalidation (e.g. pub/sub)**: works but is more moving parts for the same job.

Happy to rename (e.g. `StorageCacheBypass`) if that reads better.