### PR TITLE
Add optional LocalCache storage tier for certificate assets

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -253,7 +253,7 @@ func expiresAt(cert *x509.Certificate) time.Time {
 // This method is safe for concurrent use.
 func (cfg *Config) CacheManagedCertificate(ctx context.Context, domain string) (Certificate, error) {
 	domain = cfg.transformSubject(ctx, nil, domain)
-	cert, err := cfg.loadManagedCertificate(ctx, domain)
+	cert, err := cfg.loadManagedCertificate(ctx, domain, cfg.cachedStorage())
 	if err != nil {
 		return cert, err
 	}
@@ -262,11 +262,33 @@ func (cfg *Config) CacheManagedCertificate(ctx context.Context, domain string) (
 	return cert, nil
 }
 
+// WarmLocalCache copies the certificate assets for domain from Storage into
+// the LocalCache, so that a later handshake needing that certificate can load
+// it without reaching Storage; assets already in the local cache are left
+// alone. Unlike CacheManagedCertificate, the certificate is not put into the
+// in-memory cache, and no certificate operations are performed: this only
+// warms the local cache.
+//
+// It is an error to call this without a LocalCache configured, since there
+// would be nothing to warm. Callers warming many domains should limit their
+// concurrency.
+//
+// EXPERIMENTAL: Subject to change or removal.
+func (cfg *Config) WarmLocalCache(ctx context.Context, domain string) error {
+	if cfg.LocalCache == nil {
+		return fmt.Errorf("no local cache configured; nothing to warm")
+	}
+	domain = cfg.transformSubject(ctx, nil, domain)
+	_, err := cfg.loadCertResourceAnyIssuer(ctx, domain, cfg.cachedStorage())
+	return err
+}
+
 // loadManagedCertificate loads the managed certificate for domain from any
 // of the configured issuers' storage locations, but it does not add it to
-// the cache. It just loads from storage and returns it.
-func (cfg *Config) loadManagedCertificate(ctx context.Context, domain string) (Certificate, error) {
-	certRes, err := cfg.loadCertResourceAnyIssuer(ctx, domain)
+// the cache. It just loads from the given storage and returns it: see
+// cachedStorage and groundTruthStorage.
+func (cfg *Config) loadManagedCertificate(ctx context.Context, domain string, storage Storage) (Certificate, error) {
+	certRes, err := cfg.loadCertResourceAnyIssuer(ctx, domain, storage)
 	if err != nil {
 		return Certificate{}, err
 	}
@@ -346,7 +368,7 @@ func (cfg *Config) CacheUnmanagedTLSCertificate(ctx context.Context, tlsCert tls
 			zap.Strings("sans", cert.Names))
 	}
 	if !cfg.OCSP.DisableStapling {
-		err = stapleOCSP(ctx, cfg.OCSP, cfg.Storage, &cert, nil)
+		err = stapleOCSP(ctx, cfg.OCSP, cfg.cachedStorage(), &cert, nil)
 		if err != nil {
 			if errors.Is(err, ErrNoOCSPServerSpecified) {
 				cfg.Logger.Debug("stapling OCSP", zap.Error(err))
@@ -432,7 +454,7 @@ func (cfg Config) makeCertificateWithOCSP(ctx context.Context, certPEMBlock, key
 		return cert, err
 	}
 	if !cfg.OCSP.DisableStapling {
-		err = stapleOCSP(ctx, cfg.OCSP, cfg.Storage, &cert, certPEMBlock)
+		err = stapleOCSP(ctx, cfg.OCSP, cfg.cachedStorage(), &cert, certPEMBlock)
 		if errors.Is(err, ErrNoOCSPServerSpecified) {
 			cfg.Logger.Debug("stapling OCSP", zap.Error(err), zap.Strings("identifiers", cert.Names))
 		} else if err != nil {
@@ -531,7 +553,9 @@ func fillCertFromLeaf(cert *Certificate, tlsCert tls.Certificate) error {
 // meantime, and it would be a good idea to simply load the cert
 // into our cache rather than repeating the renewal process again.
 func (cfg *Config) managedCertInStorageNeedsRenewal(ctx context.Context, cert Certificate) (bool, error) {
-	certRes, err := cfg.loadCertResourceAnyIssuer(ctx, cert.Names[0])
+	// this decides whether we renew, so it must observe what the rest of
+	// the cluster sees, not a possibly-stale local cache
+	certRes, err := cfg.loadCertResourceAnyIssuer(ctx, cert.Names[0], cfg.groundTruthStorage())
 	if err != nil {
 		return false, err
 	}
@@ -546,7 +570,9 @@ func (cfg *Config) managedCertInStorageNeedsRenewal(ctx context.Context, cert Ce
 // already in storage. It returns the newly-loaded certificate if successful.
 func (cfg *Config) reloadManagedCertificate(ctx context.Context, oldCert Certificate) (Certificate, error) {
 	cfg.Logger.Info("reloading managed certificate", zap.Strings("identifiers", oldCert.Names))
-	newCert, err := cfg.loadManagedCertificate(ctx, oldCert.Names[0])
+	// the point of reloading is usually to pick up a renewal from another
+	// instance, so read storage rather than the local cache
+	newCert, err := cfg.loadManagedCertificate(ctx, oldCert.Names[0], cfg.groundTruthStorage())
 	if err != nil {
 		return Certificate{}, fmt.Errorf("loading managed certificate for %v from storage: %v", oldCert.Names, err)
 	}

--- a/config.go
+++ b/config.go
@@ -131,6 +131,29 @@ type Config struct {
 	// TLS assets. Default is the local file system.
 	Storage Storage
 
+	// LocalCache is an optional, node-local Storage (for example a
+	// FileStorage on a local disk) used as a read-through cache in
+	// front of Storage for a certificate's assets: its certificate,
+	// private key, and metadata files, and its OCSP staple. This is
+	// useful when Storage is remote or high-latency, since assets are
+	// loaded from storage during handshakes whenever the in-memory
+	// cache does not have the certificate.
+	//
+	// Only reads that serve certificates are answered locally.
+	// Operations that coordinate with the rest of the cluster --
+	// renewals, issuance, and reloading a certificate that another
+	// instance renewed -- read Storage directly, and locking is never
+	// local; they all refresh the local cache with what they read.
+	// Writes and deletions go to Storage first, then to the local
+	// cache. Since it is only a cache, it may be cleared at any time.
+	//
+	// Beware that this stores private keys on every instance that
+	// serves them, so the local cache should be at least as secure
+	// as Storage.
+	//
+	// EXPERIMENTAL: Subject to change or removal.
+	LocalCache Storage
+
 	// CertMagic will verify the storage configuration
 	// is acceptable before obtaining a certificate
 	// to avoid information loss after an expensive
@@ -272,6 +295,9 @@ func newWithCache(certCache *Cache, cfg Config) *Config {
 	if cfg.Storage == nil {
 		cfg.Storage = Default.Storage
 	}
+	if cfg.LocalCache == nil {
+		cfg.LocalCache = Default.LocalCache
+	}
 	if cfg.Logger == nil {
 		cfg.Logger = Default.Logger
 	}
@@ -352,7 +378,7 @@ func (cfg *Config) ClientCredentials(ctx context.Context, identifiers []string) 
 	}
 	var chains []tls.Certificate
 	for _, id := range identifiers {
-		certRes, err := cfg.loadCertResourceAnyIssuer(ctx, id)
+		certRes, err := cfg.loadCertResourceAnyIssuer(ctx, id, cfg.groundTruthStorage())
 		if err != nil {
 			return chains, err
 		}
@@ -863,8 +889,9 @@ func (cfg *Config) renewCert(ctx context.Context, name string, force, interactiv
 			}
 		}
 
-		// prepare for renewal (load PEM cert, key, and meta)
-		certRes, err := cfg.loadCertResourceAnyIssuer(ctx, name)
+		// prepare for renewal (load PEM cert, key, and meta); we hold the lock,
+		// so read storage to see if another instance already renewed this
+		certRes, err := cfg.loadCertResourceAnyIssuer(ctx, name, cfg.groundTruthStorage())
 		if err != nil {
 			return err
 		}
@@ -1108,7 +1135,7 @@ func (cfg *Config) RevokeCert(ctx context.Context, domain string, reason int, in
 			return fmt.Errorf("issuer %d (%s) is not a Revoker", i, issuerKey)
 		}
 
-		certRes, err := cfg.loadCertResource(ctx, issuer, domain)
+		certRes, err := cfg.loadCertResource(ctx, issuer, domain, cfg.groundTruthStorage())
 		if err != nil {
 			return err
 		}
@@ -1303,19 +1330,20 @@ func (cfg *Config) storageHasCertResources(ctx context.Context, issuer Issuer, d
 // certificate, private key, and metadata file for domain from the
 // issuer with the given issuer key.
 func (cfg *Config) deleteSiteAssets(ctx context.Context, issuerKey, domain string) error {
-	err := cfg.Storage.Delete(ctx, StorageKeys.SiteCert(issuerKey, domain))
+	storage := cfg.groundTruthStorage()
+	err := storage.Delete(ctx, StorageKeys.SiteCert(issuerKey, domain))
 	if err != nil {
 		return fmt.Errorf("deleting certificate file: %v", err)
 	}
-	err = cfg.Storage.Delete(ctx, StorageKeys.SitePrivateKey(issuerKey, domain))
+	err = storage.Delete(ctx, StorageKeys.SitePrivateKey(issuerKey, domain))
 	if err != nil {
 		return fmt.Errorf("deleting private key: %v", err)
 	}
-	err = cfg.Storage.Delete(ctx, StorageKeys.SiteMeta(issuerKey, domain))
+	err = storage.Delete(ctx, StorageKeys.SiteMeta(issuerKey, domain))
 	if err != nil {
 		return fmt.Errorf("deleting metadata file: %v", err)
 	}
-	err = cfg.Storage.Delete(ctx, StorageKeys.CertsSitePrefix(issuerKey, domain))
+	err = storage.Delete(ctx, StorageKeys.CertsSitePrefix(issuerKey, domain))
 	if err != nil {
 		return fmt.Errorf("deleting site asset folder: %v", err)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -66,7 +66,7 @@ func TestSaveCertResource(t *testing.T) {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
 
-	siteData, err := testConfig.loadCertResource(ctx, am, domain)
+	siteData, err := testConfig.loadCertResource(ctx, am, domain, testConfig.groundTruthStorage())
 	if err != nil {
 		t.Fatalf("Expected no error reading site, got: %v", err)
 	}

--- a/crypto.go
+++ b/crypto.go
@@ -167,19 +167,20 @@ func (cfg *Config) saveCertResource(ctx context.Context, issuer Issuer, cert Cer
 		},
 	}
 
-	return storeTx(ctx, cfg.Storage, all)
+	return storeTx(ctx, cfg.groundTruthStorage(), all)
 }
 
 // loadCertResourceAnyIssuer loads and returns the certificate resource from any
 // of the configured issuers. If multiple are found (e.g. if there are 3 issuers
 // configured, and all 3 have a resource matching certNamesKey), then the newest
-// (latest NotBefore date) resource will be chosen.
-func (cfg *Config) loadCertResourceAnyIssuer(ctx context.Context, certNamesKey string) (CertificateResource, error) {
+// (latest NotBefore date) resource will be chosen. Callers pass the storage
+// to load from: see cachedStorage and groundTruthStorage.
+func (cfg *Config) loadCertResourceAnyIssuer(ctx context.Context, certNamesKey string, storage Storage) (CertificateResource, error) {
 	// we can save some extra decoding steps if there's only one issuer, since
 	// we don't need to compare potentially multiple available resources to
 	// select the best one, when there's only one choice anyway
 	if len(cfg.Issuers) == 1 {
-		return cfg.loadCertResource(ctx, cfg.Issuers[0], certNamesKey)
+		return cfg.loadCertResource(ctx, cfg.Issuers[0], certNamesKey, storage)
 	}
 
 	type decodedCertResource struct {
@@ -193,7 +194,7 @@ func (cfg *Config) loadCertResourceAnyIssuer(ctx context.Context, certNamesKey s
 	// load and decode all certificate resources found with the
 	// configured issuers so we can sort by newest
 	for _, issuer := range cfg.Issuers {
-		certRes, err := cfg.loadCertResource(ctx, issuer, certNamesKey)
+		certRes, err := cfg.loadCertResource(ctx, issuer, certNamesKey, storage)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				// not a problem, but we need to remember the error
@@ -236,8 +237,9 @@ func (cfg *Config) loadCertResourceAnyIssuer(ctx context.Context, certNamesKey s
 	return certResources[0].CertificateResource, nil
 }
 
-// loadCertResource loads a certificate resource from the given issuer's storage location.
-func (cfg *Config) loadCertResource(ctx context.Context, issuer Issuer, certNamesKey string) (CertificateResource, error) {
+// loadCertResource loads a certificate resource from the given issuer's storage
+// location, using the given storage: see cachedStorage and groundTruthStorage.
+func (cfg *Config) loadCertResource(ctx context.Context, issuer Issuer, certNamesKey string, storage Storage) (CertificateResource, error) {
 	certRes := CertificateResource{issuerKey: issuer.IssuerKey()}
 
 	// don't use the Lookup profile because we might be loading a wildcard cert which is rejected by the Lookup profile
@@ -246,17 +248,17 @@ func (cfg *Config) loadCertResource(ctx context.Context, issuer Issuer, certName
 		return CertificateResource{}, fmt.Errorf("converting '%s' to ASCII: %v", certNamesKey, err)
 	}
 
-	keyBytes, err := cfg.Storage.Load(ctx, StorageKeys.SitePrivateKey(certRes.issuerKey, normalizedName))
+	keyBytes, err := storage.Load(ctx, StorageKeys.SitePrivateKey(certRes.issuerKey, normalizedName))
 	if err != nil {
 		return CertificateResource{}, err
 	}
 	certRes.PrivateKeyPEM = keyBytes
-	certBytes, err := cfg.Storage.Load(ctx, StorageKeys.SiteCert(certRes.issuerKey, normalizedName))
+	certBytes, err := storage.Load(ctx, StorageKeys.SiteCert(certRes.issuerKey, normalizedName))
 	if err != nil {
 		return CertificateResource{}, err
 	}
 	certRes.CertificatePEM = certBytes
-	metaBytes, err := cfg.Storage.Load(ctx, StorageKeys.SiteMeta(certRes.issuerKey, normalizedName))
+	metaBytes, err := storage.Load(ctx, StorageKeys.SiteMeta(certRes.issuerKey, normalizedName))
 	if err != nil {
 		return CertificateResource{}, err
 	}

--- a/handshake.go
+++ b/handshake.go
@@ -610,7 +610,7 @@ func (cfg *Config) handshakeMaintenance(ctx context.Context, hello *tls.ClientHe
 			zap.Time("this_update", cert.ocsp.ThisUpdate),
 			zap.Time("next_update", cert.ocsp.NextUpdate))
 
-		err := stapleOCSP(ctx, cfg.OCSP, cfg.Storage, &cert, nil)
+		err := stapleOCSP(ctx, cfg.OCSP, cfg.cachedStorage(), &cert, nil)
 		if err != nil {
 			// An error with OCSP stapling is not the end of the world, and in fact, is
 			// quite common considering not all certs have issuer URLs that support it.

--- a/localcache.go
+++ b/localcache.go
@@ -1,0 +1,125 @@
+// Copyright 2015 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certmagic
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+
+	"go.uber.org/zap"
+)
+
+// cachedStorage returns the Storage to use for a certificate's assets when
+// they are being loaded in order to serve the certificate. If a LocalCache
+// is configured, loads are answered from it whenever it has the asset.
+func (cfg *Config) cachedStorage() Storage {
+	return cfg.certStorage(true)
+}
+
+// groundTruthStorage returns the Storage to use for a certificate's assets
+// when the caller has to observe what the rest of the cluster sees, such as
+// when renewing, issuing, or reloading a certificate that another instance
+// renewed. Loads go to Storage, but they still refresh the LocalCache with
+// what they read, so a stale local copy doesn't stay stale.
+func (cfg *Config) groundTruthStorage() Storage {
+	return cfg.certStorage(false)
+}
+
+// certStorage returns the Storage to use for a certificate's assets: its
+// certificate, private key, and metadata files, and its OCSP staple. If a
+// LocalCache is configured, the returned Storage keeps it up to date with
+// everything it loads, stores, and deletes. Prefer calling cachedStorage or
+// groundTruthStorage, which name the two ways to use it.
+func (cfg *Config) certStorage(readLocal bool) Storage {
+	if cfg.LocalCache == nil {
+		return cfg.Storage
+	}
+	return localCacheStorage{
+		Storage:   cfg.Storage,
+		local:     cfg.LocalCache,
+		readLocal: readLocal,
+		logger:    cfg.Logger,
+	}
+}
+
+// localCacheStorage is a Storage that keeps a node-local copy of the items
+// it reads from and writes to the embedded, authoritative Storage. Only
+// Load, Store, and Delete are cached; everything else -- notably Exists,
+// List, and locking -- goes straight to the authoritative Storage, since
+// those are how instances coordinate with each other.
+//
+// The local cache is only an optimization, so its errors are logged rather
+// than returned.
+type localCacheStorage struct {
+	Storage
+	local     Storage
+	readLocal bool
+	logger    *zap.Logger
+}
+
+func (ls localCacheStorage) Load(ctx context.Context, key string) ([]byte, error) {
+	if ls.readLocal {
+		value, err := ls.local.Load(ctx, key)
+		if err == nil {
+			return value, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			ls.logger.Warn("loading from local cache; falling back to storage",
+				zap.String("key", key),
+				zap.Error(err))
+		}
+	}
+	value, err := ls.Storage.Load(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	ls.cacheLocally(ctx, key, value)
+	return value, nil
+}
+
+func (ls localCacheStorage) Store(ctx context.Context, key string, value []byte) error {
+	err := ls.Storage.Store(ctx, key, value)
+	if err != nil {
+		return err
+	}
+	ls.cacheLocally(ctx, key, value)
+	return nil
+}
+
+// Delete evicts key from the local cache even if deleting it from the
+// authoritative Storage failed, so that we don't keep serving something
+// that was meant to be deleted.
+func (ls localCacheStorage) Delete(ctx context.Context, key string) error {
+	err := ls.Storage.Delete(ctx, key)
+	localErr := ls.local.Delete(ctx, key)
+	if localErr != nil && !errors.Is(localErr, fs.ErrNotExist) {
+		ls.logger.Warn("deleting from local cache",
+			zap.String("key", key),
+			zap.Error(localErr))
+	}
+	return err
+}
+
+func (ls localCacheStorage) cacheLocally(ctx context.Context, key string, value []byte) {
+	err := ls.local.Store(ctx, key, value)
+	if err != nil {
+		ls.logger.Warn("storing in local cache",
+			zap.String("key", key),
+			zap.Error(err))
+	}
+}
+
+var _ Storage = localCacheStorage{}

--- a/localcache_test.go
+++ b/localcache_test.go
@@ -1,0 +1,231 @@
+// Copyright 2015 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certmagic
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/mholt/acmez/v3/acme"
+	"golang.org/x/crypto/ocsp"
+)
+
+func testLocalCacheConfig(t *testing.T) (*Config, *ACMEIssuer, *recordingStorage, *FileStorage) {
+	t.Helper()
+	am := &ACMEIssuer{CA: "https://example.com/acme/directory"}
+	storage := &recordingStorage{Storage: &FileStorage{Path: t.TempDir()}}
+	localCache := &FileStorage{Path: t.TempDir()}
+	cfg := &Config{
+		Issuers:   []Issuer{am},
+		Storage:   storage,
+		Logger:    defaultTestLogger,
+		certCache: new(Cache),
+	}
+	am.config = cfg
+	return cfg, am, storage, localCache
+}
+
+func testCertResource(issuer Issuer, domain string) CertificateResource {
+	return CertificateResource{
+		SANs:           []string{domain},
+		PrivateKeyPEM:  []byte("private key"),
+		CertificatePEM: []byte("certificate"),
+		IssuerData:     mustJSON(acme.Certificate{URL: "https://example.com/cert"}),
+		issuerKey:      issuer.IssuerKey(),
+	}
+}
+
+func TestLocalCache(t *testing.T) {
+	ctx := context.Background()
+	const domain = "example.com"
+
+	cfg, am, storage, localCache := testLocalCacheConfig(t)
+	cfg.LocalCache = localCache
+	certKey := StorageKeys.SiteCert(am.IssuerKey(), domain)
+
+	err := cfg.saveCertResource(ctx, am, testCertResource(am, domain))
+	if err != nil {
+		t.Fatalf("Expected no error saving cert resource, got: %v", err)
+	}
+
+	// saving writes through to the local cache, so serving the
+	// certificate afterwards should not need storage at all
+	storage.calls = nil
+	certRes, err := cfg.loadCertResource(ctx, am, domain, cfg.cachedStorage())
+	if err != nil {
+		t.Fatalf("Expected no error loading cert resource, got: %v", err)
+	}
+	if string(certRes.CertificatePEM) != "certificate" {
+		t.Errorf("Expected 'certificate', got: %s", certRes.CertificatePEM)
+	}
+	if len(storage.calls) > 0 {
+		t.Errorf("Expected no storage calls, got: %v", storage.calls)
+	}
+
+	// as if another instance renewed the certificate
+	err = storage.Store(ctx, certKey, []byte("renewed certificate"))
+	if err != nil {
+		t.Fatalf("Expected no error storing renewed certificate, got: %v", err)
+	}
+
+	// cluster-sensitive loads see storage, and refresh the local cache
+	certRes, err = cfg.loadCertResource(ctx, am, domain, cfg.groundTruthStorage())
+	if err != nil {
+		t.Fatalf("Expected no error loading cert resource, got: %v", err)
+	}
+	if string(certRes.CertificatePEM) != "renewed certificate" {
+		t.Errorf("Expected 'renewed certificate', got: %s", certRes.CertificatePEM)
+	}
+	cached, err := localCache.Load(ctx, certKey)
+	if err != nil {
+		t.Fatalf("Expected no error loading from local cache, got: %v", err)
+	}
+	if string(cached) != "renewed certificate" {
+		t.Errorf("Expected local cache to be refreshed, got: %s", cached)
+	}
+
+	// deleting the site assets evicts them from the local cache too
+	err = cfg.deleteSiteAssets(ctx, am.IssuerKey(), domain)
+	if err != nil {
+		t.Fatalf("Expected no error deleting site assets, got: %v", err)
+	}
+	if localCache.Exists(ctx, certKey) {
+		t.Errorf("Expected %s to be gone from the local cache", certKey)
+	}
+}
+
+func TestLocalCacheOCSPStaple(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().Add(-1 * time.Hour)
+
+	issuerCert, issuerKey, issuerPEM := mustIssueTestCertificate(t, &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test issuer"},
+		NotBefore:             now,
+		NotAfter:              now.Add(48 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}, nil, nil)
+
+	issuedCert, issuedKey, issuedPEM := mustIssueTestCertificate(t, &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "cached.example"},
+		DNSNames:     []string{"cached.example"},
+		NotBefore:    now,
+		NotAfter:     now.Add(30 * 24 * time.Hour),
+		OCSPServer:   []string{"http://ocsp.example.test"},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}, issuerCert, issuerKey)
+
+	issuedKeyPEM, err := PEMEncodePrivateKey(issuedKey)
+	if err != nil {
+		t.Fatalf("Expected no error encoding private key, got: %v", err)
+	}
+	bundle := append(append([]byte{}, issuedPEM...), issuerPEM...)
+
+	response, err := ocsp.CreateResponse(issuerCert, issuerCert, ocsp.Response{
+		Status:       ocsp.Good,
+		SerialNumber: issuedCert.SerialNumber,
+		ThisUpdate:   now.UTC(),
+		NextUpdate:   now.Add(24 * time.Hour).UTC(),
+	}, issuerKey)
+	if err != nil {
+		t.Fatalf("Expected no error creating OCSP response, got: %v", err)
+	}
+	responder := startOCSPResponder(t, map[string][]byte{
+		issuedCert.SerialNumber.String(): response,
+	})
+	t.Cleanup(responder.Close)
+
+	cfg, _, storage, localCache := testLocalCacheConfig(t)
+	cfg.LocalCache = localCache
+	cfg.OCSP = OCSPConfig{
+		ResponderOverrides: map[string]string{"http://ocsp.example.test": responder.URL},
+	}
+
+	// the first staple comes from the responder, and is written to both
+	cert, err := makeCertificate(issuedPEM, issuedKeyPEM)
+	if err != nil {
+		t.Fatalf("Expected no error making certificate, got: %v", err)
+	}
+	err = stapleOCSP(ctx, cfg.OCSP, cfg.cachedStorage(), &cert, bundle)
+	if err != nil {
+		t.Fatalf("Expected no error stapling OCSP, got: %v", err)
+	}
+	if !bytes.Equal(cert.Certificate.OCSPStaple, response) {
+		t.Fatal("Expected OCSP response to be stapled to certificate")
+	}
+
+	// stapling the same certificate again is served from the local cache
+	storage.calls = nil
+	cert, err = makeCertificate(issuedPEM, issuedKeyPEM)
+	if err != nil {
+		t.Fatalf("Expected no error making certificate, got: %v", err)
+	}
+	err = stapleOCSP(ctx, cfg.OCSP, cfg.cachedStorage(), &cert, bundle)
+	if err != nil {
+		t.Fatalf("Expected no error stapling OCSP, got: %v", err)
+	}
+	if !bytes.Equal(cert.Certificate.OCSPStaple, response) {
+		t.Error("Expected OCSP response to be stapled from the local cache")
+	}
+	if len(storage.calls) > 0 {
+		t.Errorf("Expected no storage calls, got: %v", storage.calls)
+	}
+}
+
+func TestWarmLocalCache(t *testing.T) {
+	ctx := context.Background()
+	const domain = "example.com"
+
+	cfg, am, storage, localCache := testLocalCacheConfig(t)
+
+	// no local cache yet, so this only writes to storage
+	err := cfg.saveCertResource(ctx, am, testCertResource(am, domain))
+	if err != nil {
+		t.Fatalf("Expected no error saving cert resource, got: %v", err)
+	}
+	if err = cfg.WarmLocalCache(ctx, domain); err == nil {
+		t.Error("Expected an error warming without a local cache, got none")
+	}
+
+	cfg.LocalCache = localCache
+	err = cfg.WarmLocalCache(ctx, domain)
+	if err != nil {
+		t.Fatalf("Expected no error warming local cache, got: %v", err)
+	}
+
+	storage.calls = nil
+	_, err = cfg.loadCertResource(ctx, am, domain, cfg.cachedStorage())
+	if err != nil {
+		t.Fatalf("Expected no error loading cert resource, got: %v", err)
+	}
+	if len(storage.calls) > 0 {
+		t.Errorf("Expected no storage calls after warming, got: %v", storage.calls)
+	}
+
+	// warming a certificate that isn't in storage must not be silently ignored
+	err = cfg.WarmLocalCache(ctx, "not-in-storage.example.com")
+	if err == nil {
+		t.Error("Expected an error warming an unknown domain, got none")
+	}
+}

--- a/maintain.go
+++ b/maintain.go
@@ -347,7 +347,9 @@ func (certCache *Cache) updateOCSPStaples(ctx context.Context) {
 			continue
 		}
 
-		err := stapleOCSP(ctx, qe.cfg.OCSP, qe.cfg.Storage, &cert, nil)
+		// this is the background refresher, so read storage rather than the
+		// local cache to pick up staples refreshed by other instances
+		err := stapleOCSP(ctx, qe.cfg.OCSP, qe.cfg.groundTruthStorage(), &cert, nil)
 		if err != nil {
 			if cert.ocsp != nil {
 				// if there was no staple before, that's fine; otherwise we should log the error


### PR DESCRIPTION
Certificates are loaded from Storage during handshakes whenever the in-memory cache misses, which is slow when Storage is remote. This adds an optional Config.LocalCache Storage that sits between the two: reads that serve certificates are answered locally, while the operations that coordinate with the rest of the cluster (renewals, issuance, and reloading a certificate a peer renewed) read Storage directly and refresh the local cache with what they read. Writes and deletions go to Storage first, then to the local cache; locking is never local.

Callers pick between the two with cachedStorage and groundTruthStorage. Certificate, key, and metadata files and OCSP staples all go through the same path. WarmLocalCache pre-populates the local cache for a subject without touching the in-memory cache or doing any certificate operations.

The field is nil by default, so behavior is unchanged when it is unset.

Build with Claude Opus 5

If the direction of this PR is good/workable, I'm happy to run some field tests with it.