### PR TITLE
handshake: skip building event data nobody will see

### DIFF
--- a/config.go
+++ b/config.go
@@ -70,6 +70,13 @@ type Config struct {
 	// ignore returned errors.
 	OnEvent func(ctx context.Context, event string, data map[string]any) error
 
+	// An optional callback reporting whether OnEvent
+	// has a subscriber for the named event. If unset,
+	// every event is assumed observed. Lets CertMagic
+	// skip building data nobody will see; it is called
+	// concurrently during handshakes, so keep it fast.
+	HasEventSubscribersFunc func(event string) bool
+
 	// DefaultServerName specifies a server name
 	// to use when choosing a certificate if the
 	// ClientHello's ServerName field is empty.
@@ -259,6 +266,9 @@ func newWithCache(certCache *Cache, cfg Config) *Config {
 	}
 	if cfg.OnEvent == nil {
 		cfg.OnEvent = Default.OnEvent
+	}
+	if cfg.HasEventSubscribersFunc == nil {
+		cfg.HasEventSubscribersFunc = Default.HasEventSubscribersFunc
 	}
 	if cfg.KeySource == nil {
 		cfg.KeySource = Default.KeySource
@@ -1352,6 +1362,20 @@ func (cfg *Config) emit(ctx context.Context, eventName string, data map[string]a
 		return nil
 	}
 	return cfg.OnEvent(ctx, eventName, data)
+}
+
+// eventHasSubscriber reports whether emitting the named event could reach
+// anything. Callers use it to avoid building an event's data when nothing
+// will see it; emit() cannot do that itself, since Go evaluates arguments
+// before it is entered. Only worth consulting on hot paths.
+func (cfg *Config) eventHasSubscriber(eventName string) bool {
+	if cfg.OnEvent == nil {
+		return false
+	}
+	if cfg.HasEventSubscribersFunc == nil {
+		return true // no way to ask; assume it is
+	}
+	return cfg.HasEventSubscribersFunc(eventName)
 }
 
 // CertificateSelector is a type which can select a certificate to use given multiple choices.

--- a/config.go
+++ b/config.go
@@ -70,12 +70,15 @@ type Config struct {
 	// ignore returned errors.
 	OnEvent func(ctx context.Context, event string, data map[string]any) error
 
-	// An optional callback reporting whether OnEvent
-	// has a subscriber for the named event. If unset,
-	// every event is assumed observed. Lets CertMagic
-	// skip building data nobody will see; it is called
-	// concurrently during handshakes, so keep it fast.
-	HasEventSubscribersFunc func(event string) bool
+	// An optional callback reporting whether an event
+	// is worth emitting. Returning false skips the
+	// OnEvent call entirely, so it must account for
+	// everything OnEvent does -- logging, metrics --
+	// not only subscribed handlers, and must never
+	// answer no for an event something would observe.
+	// If unset, every event is emitted. Called during
+	// handshakes and concurrently; keep it fast.
+	ShouldEmitFunc func(event string) bool
 
 	// DefaultServerName specifies a server name
 	// to use when choosing a certificate if the
@@ -266,9 +269,12 @@ func newWithCache(certCache *Cache, cfg Config) *Config {
 	}
 	if cfg.OnEvent == nil {
 		cfg.OnEvent = Default.OnEvent
-	}
-	if cfg.HasEventSubscribersFunc == nil {
-		cfg.HasEventSubscribersFunc = Default.HasEventSubscribersFunc
+		// the predicate is written for a specific handler, so it only
+		// comes along with the handler it belongs to; inheriting it onto
+		// a caller's own OnEvent could silence events it wants
+		if cfg.ShouldEmitFunc == nil {
+			cfg.ShouldEmitFunc = Default.ShouldEmitFunc
+		}
 	}
 	if cfg.KeySource == nil {
 		cfg.KeySource = Default.KeySource
@@ -1364,18 +1370,18 @@ func (cfg *Config) emit(ctx context.Context, eventName string, data map[string]a
 	return cfg.OnEvent(ctx, eventName, data)
 }
 
-// eventHasSubscriber reports whether emitting the named event could reach
+// shouldEmit reports whether emitting the named event could reach
 // anything. Callers use it to avoid building an event's data when nothing
 // will see it; emit() cannot do that itself, since Go evaluates arguments
 // before it is entered. Only worth consulting on hot paths.
-func (cfg *Config) eventHasSubscriber(eventName string) bool {
+func (cfg *Config) shouldEmit(eventName string) bool {
 	if cfg.OnEvent == nil {
 		return false
 	}
-	if cfg.HasEventSubscribersFunc == nil {
+	if cfg.ShouldEmitFunc == nil {
 		return true // no way to ask; assume it is
 	}
-	return cfg.HasEventSubscribersFunc(eventName)
+	return cfg.ShouldEmitFunc(eventName)
 }
 
 // CertificateSelector is a type which can select a certificate to use given multiple choices.

--- a/events_test.go
+++ b/events_test.go
@@ -1,0 +1,242 @@
+// Copyright 2015 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certmagic
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func TestEventObservable(t *testing.T) {
+	noop := func(context.Context, string, map[string]any) error { return nil }
+
+	for _, tc := range []struct {
+		name    string
+		cfg     Config
+		expects bool
+	}{
+		{
+			name:    "no handler at all",
+			cfg:     Config{},
+			expects: false,
+		},
+		{
+			name:    "handler, but no way to ask about subscribers",
+			cfg:     Config{OnEvent: noop},
+			expects: true,
+		},
+		{
+			name:    "handler says it has a subscriber",
+			cfg:     Config{OnEvent: noop, HasEventSubscribersFunc: func(string) bool { return true }},
+			expects: true,
+		},
+		{
+			name:    "handler says it has no subscriber",
+			cfg:     Config{OnEvent: noop, HasEventSubscribersFunc: func(string) bool { return false }},
+			expects: false,
+		},
+		{
+			name:    "no handler outweighs a subscriber claim",
+			cfg:     Config{HasEventSubscribersFunc: func(string) bool { return true }},
+			expects: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.eventHasSubscriber("tls_get_certificate"); got != tc.expects {
+				t.Errorf("eventHasSubscriber() = %v, want %v", got, tc.expects)
+			}
+		})
+	}
+}
+
+// The event name has to reach HasEventSubscribersFunc, or a caller cannot
+// distinguish the handshake event from the rest.
+func TestShouldEmitReceivesEventName(t *testing.T) {
+	var asked []string
+	cfg := Config{
+		OnEvent:                 func(context.Context, string, map[string]any) error { return nil },
+		HasEventSubscribersFunc: func(name string) bool { asked = append(asked, name); return false },
+	}
+
+	cfg.eventHasSubscriber("cert_obtained")
+	cfg.eventHasSubscriber("tls_get_certificate")
+
+	if len(asked) != 2 || asked[0] != "cert_obtained" || asked[1] != "tls_get_certificate" {
+		t.Errorf("HasEventSubscribersFunc was asked about %v", asked)
+	}
+}
+
+func testCertificate(tb testing.TB) tls.Certificate {
+	tb.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "example.com"},
+		DNSNames:     []string{"example.com"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}
+}
+
+type testConn struct{ net.Conn }
+
+func (testConn) RemoteAddr() net.Addr { return &net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 51234} }
+func (testConn) LocalAddr() net.Addr  { return &net.TCPAddr{IP: net.IPv4(10, 0, 0, 2), Port: 443} }
+
+func testClientHello() *tls.ClientHelloInfo {
+	return &tls.ClientHelloInfo{
+		ServerName:        "example.com",
+		CipherSuites:      []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, tls.TLS_AES_128_GCM_SHA256},
+		SupportedCurves:   []tls.CurveID{tls.CurveP256, tls.X25519},
+		SupportedPoints:   []uint8{0},
+		SupportedVersions: []uint16{tls.VersionTLS13, tls.VersionTLS12},
+		SignatureSchemes:  []tls.SignatureScheme{tls.ECDSAWithP256AndSHA256},
+		Conn:              testConn{},
+	}
+}
+
+// handshakeConfig returns a Config serving one cached certificate for
+// example.com, with the given event hooks installed.
+func handshakeConfig(tb testing.TB, onEvent func(context.Context, string, map[string]any) error, hasSubs func(string) bool) *Config {
+	tb.Helper()
+
+	var cfg *Config
+	cache := NewCache(CacheOptions{
+		GetConfigForCert: func(Certificate) (*Config, error) { return cfg, nil },
+		Logger:           zap.NewNop(),
+	})
+	tb.Cleanup(cache.Stop)
+
+	cfg = New(cache, Config{
+		Storage:                 &FileStorage{Path: tb.TempDir()},
+		Logger:                  zap.NewNop(),
+		OnEvent:                 onEvent,
+		HasEventSubscribersFunc: hasSubs,
+	})
+	if _, err := cfg.CacheUnmanagedTLSCertificate(context.Background(), testCertificate(tb), nil); err != nil {
+		tb.Fatal(err)
+	}
+	return cfg
+}
+
+func TestGetCertificateSkipsUnobservedEvent(t *testing.T) {
+	var emitted []string
+	record := func(_ context.Context, name string, _ map[string]any) error {
+		emitted = append(emitted, name)
+		return nil
+	}
+
+	t.Run("subscribed", func(t *testing.T) {
+		cfg := handshakeConfig(t, record, func(string) bool { return true })
+		emitted = nil // drop what caching the certificate emitted
+		if _, err := cfg.GetCertificate(testClientHello()); err != nil {
+			t.Fatal(err)
+		}
+		if len(emitted) != 1 || emitted[0] != "tls_get_certificate" {
+			t.Errorf("emitted %v, want [tls_get_certificate]", emitted)
+		}
+	})
+
+	t.Run("not subscribed", func(t *testing.T) {
+		cfg := handshakeConfig(t, record, func(string) bool { return false })
+		emitted = nil // drop what caching the certificate emitted
+		if _, err := cfg.GetCertificate(testClientHello()); err != nil {
+			t.Fatal(err)
+		}
+		if len(emitted) != 0 {
+			t.Errorf("emitted %v, want nothing", emitted)
+		}
+	})
+
+	t.Run("no way to ask", func(t *testing.T) {
+		cfg := handshakeConfig(t, record, nil)
+		emitted = nil // drop what caching the certificate emitted
+		if _, err := cfg.GetCertificate(testClientHello()); err != nil {
+			t.Fatal(err)
+		}
+		if len(emitted) != 1 {
+			t.Errorf("emitted %v, want [tls_get_certificate]", emitted)
+		}
+	})
+}
+
+// A subscribed handler can still abort the handshake.
+func TestGetCertificateHonorsEventAbort(t *testing.T) {
+	abort := errors.New("nope")
+	cfg := handshakeConfig(t,
+		func(context.Context, string, map[string]any) error { return abort },
+		func(string) bool { return true })
+
+	if _, err := cfg.GetCertificate(testClientHello()); !errors.Is(err, abort) {
+		t.Errorf("got error %v, want it to wrap %v", err, abort)
+	}
+}
+
+// What a handshake pays for tls_get_certificate when something is subscribed
+// to it: the data is built and dispatched, as before.
+func BenchmarkGetCertificateEventSubscribed(b *testing.B) {
+	cfg := handshakeConfig(b,
+		func(context.Context, string, map[string]any) error { return nil },
+		func(string) bool { return true })
+	benchmarkGetCertificate(b, cfg)
+}
+
+// The common case: a handler is installed for other events, but nothing is
+// subscribed to this one.
+func BenchmarkGetCertificateEventUnsubscribed(b *testing.B) {
+	cfg := handshakeConfig(b,
+		func(context.Context, string, map[string]any) error { return nil },
+		func(string) bool { return false })
+	benchmarkGetCertificate(b, cfg)
+}
+
+func benchmarkGetCertificate(b *testing.B, cfg *Config) {
+	b.Helper()
+	hello := testClientHello()
+	if _, err := cfg.GetCertificate(hello); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := cfg.GetCertificate(hello); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/events_test.go
+++ b/events_test.go
@@ -31,7 +31,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestEventObservable(t *testing.T) {
+func TestShouldEmit(t *testing.T) {
 	noop := func(context.Context, string, map[string]any) error { return nil }
 
 	for _, tc := range []struct {
@@ -51,42 +51,42 @@ func TestEventObservable(t *testing.T) {
 		},
 		{
 			name:    "handler says it has a subscriber",
-			cfg:     Config{OnEvent: noop, HasEventSubscribersFunc: func(string) bool { return true }},
+			cfg:     Config{OnEvent: noop, ShouldEmitFunc: func(string) bool { return true }},
 			expects: true,
 		},
 		{
 			name:    "handler says it has no subscriber",
-			cfg:     Config{OnEvent: noop, HasEventSubscribersFunc: func(string) bool { return false }},
+			cfg:     Config{OnEvent: noop, ShouldEmitFunc: func(string) bool { return false }},
 			expects: false,
 		},
 		{
 			name:    "no handler outweighs a subscriber claim",
-			cfg:     Config{HasEventSubscribersFunc: func(string) bool { return true }},
+			cfg:     Config{ShouldEmitFunc: func(string) bool { return true }},
 			expects: false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.cfg.eventHasSubscriber("tls_get_certificate"); got != tc.expects {
-				t.Errorf("eventHasSubscriber() = %v, want %v", got, tc.expects)
+			if got := tc.cfg.shouldEmit("tls_get_certificate"); got != tc.expects {
+				t.Errorf("shouldEmit() = %v, want %v", got, tc.expects)
 			}
 		})
 	}
 }
 
-// The event name has to reach HasEventSubscribersFunc, or a caller cannot
+// The event name has to reach ShouldEmitFunc, or a caller cannot
 // distinguish the handshake event from the rest.
 func TestShouldEmitReceivesEventName(t *testing.T) {
 	var asked []string
 	cfg := Config{
-		OnEvent:                 func(context.Context, string, map[string]any) error { return nil },
-		HasEventSubscribersFunc: func(name string) bool { asked = append(asked, name); return false },
+		OnEvent:        func(context.Context, string, map[string]any) error { return nil },
+		ShouldEmitFunc: func(name string) bool { asked = append(asked, name); return false },
 	}
 
-	cfg.eventHasSubscriber("cert_obtained")
-	cfg.eventHasSubscriber("tls_get_certificate")
+	cfg.shouldEmit("cert_obtained")
+	cfg.shouldEmit("tls_get_certificate")
 
 	if len(asked) != 2 || asked[0] != "cert_obtained" || asked[1] != "tls_get_certificate" {
-		t.Errorf("HasEventSubscribersFunc was asked about %v", asked)
+		t.Errorf("ShouldEmitFunc was asked about %v", asked)
 	}
 }
 
@@ -144,10 +144,10 @@ func handshakeConfig(tb testing.TB, onEvent func(context.Context, string, map[st
 	tb.Cleanup(cache.Stop)
 
 	cfg = New(cache, Config{
-		Storage:                 &FileStorage{Path: tb.TempDir()},
-		Logger:                  zap.NewNop(),
-		OnEvent:                 onEvent,
-		HasEventSubscribersFunc: hasSubs,
+		Storage:        &FileStorage{Path: tb.TempDir()},
+		Logger:         zap.NewNop(),
+		OnEvent:        onEvent,
+		ShouldEmitFunc: hasSubs,
 	})
 	if _, err := cfg.CacheUnmanagedTLSCertificate(context.Background(), testCertificate(tb), nil); err != nil {
 		tb.Fatal(err)
@@ -239,4 +239,59 @@ func benchmarkGetCertificate(b *testing.B, cfg *Config) {
 			b.Fatal(err)
 		}
 	}
+}
+
+// The predicate is written against a particular OnEvent, so a config that
+// brings its own handler must not inherit Default's predicate: it knows
+// nothing about that handler and would silence it.
+func TestShouldEmitFuncInheritedWithOnEvent(t *testing.T) {
+	defaultOnEvent := func(context.Context, string, map[string]any) error { return nil }
+	defaultPredicate := func(string) bool { return false }
+
+	oldOnEvent, oldPredicate := Default.OnEvent, Default.ShouldEmitFunc
+	Default.OnEvent, Default.ShouldEmitFunc = defaultOnEvent, defaultPredicate
+	t.Cleanup(func() { Default.OnEvent, Default.ShouldEmitFunc = oldOnEvent, oldPredicate })
+
+	newConfig := func(tb testing.TB, cfg Config) *Config {
+		tb.Helper()
+		var out *Config
+		cache := NewCache(CacheOptions{
+			GetConfigForCert: func(Certificate) (*Config, error) { return out, nil },
+			Logger:           zap.NewNop(),
+		})
+		tb.Cleanup(cache.Stop)
+		cfg.Storage = &FileStorage{Path: tb.TempDir()}
+		cfg.Logger = zap.NewNop()
+		out = New(cache, cfg)
+		return out
+	}
+
+	t.Run("own handler does not inherit the predicate", func(t *testing.T) {
+		cfg := newConfig(t, Config{
+			OnEvent: func(context.Context, string, map[string]any) error { return nil },
+		})
+		if cfg.ShouldEmitFunc != nil {
+			t.Error("inherited Default's predicate onto a caller's own OnEvent")
+		}
+		if !cfg.shouldEmit("tls_get_certificate") {
+			t.Error("caller's handler is being silenced")
+		}
+	})
+
+	t.Run("inherited handler brings its predicate", func(t *testing.T) {
+		cfg := newConfig(t, Config{})
+		if cfg.ShouldEmitFunc == nil {
+			t.Fatal("did not inherit Default's predicate alongside Default's OnEvent")
+		}
+		if cfg.shouldEmit("tls_get_certificate") {
+			t.Error("Default's predicate is not being consulted")
+		}
+	})
+
+	t.Run("own predicate is kept", func(t *testing.T) {
+		cfg := newConfig(t, Config{ShouldEmitFunc: func(string) bool { return true }})
+		if !cfg.shouldEmit("tls_get_certificate") {
+			t.Error("caller's own predicate was replaced")
+		}
+	})
 }

--- a/handshake.go
+++ b/handshake.go
@@ -51,12 +51,16 @@ func (cfg *Config) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certif
 }
 
 func (cfg *Config) GetCertificateWithContext(ctx context.Context, clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	if err := cfg.emit(ctx, "tls_get_certificate", map[string]any{"client_hello": clientHelloWithoutConn(clientHello)}); err != nil {
-		cfg.Logger.Error("TLS handshake aborted by event handler",
-			zap.String("server_name", clientHello.ServerName),
-			zap.String("remote", clientHello.Conn.RemoteAddr().String()),
-			zap.Error(err))
-		return nil, fmt.Errorf("handshake aborted by event handler: %w", err)
+	// this runs for every handshake, and building the event's data is not
+	// free, so don't do it unless something is actually listening
+	if cfg.eventHasSubscriber("tls_get_certificate") {
+		if err := cfg.emit(ctx, "tls_get_certificate", map[string]any{"client_hello": clientHelloWithoutConn(clientHello)}); err != nil {
+			cfg.Logger.Error("TLS handshake aborted by event handler",
+				zap.String("server_name", clientHello.ServerName),
+				zap.String("remote", clientHello.Conn.RemoteAddr().String()),
+				zap.Error(err))
+			return nil, fmt.Errorf("handshake aborted by event handler: %w", err)
+		}
 	}
 
 	if ctx == nil {

--- a/handshake.go
+++ b/handshake.go
@@ -53,7 +53,7 @@ func (cfg *Config) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certif
 func (cfg *Config) GetCertificateWithContext(ctx context.Context, clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	// this runs for every handshake, and building the event's data is not
 	// free, so don't do it unless something is actually listening
-	if cfg.eventHasSubscriber("tls_get_certificate") {
+	if cfg.shouldEmit("tls_get_certificate") {
 		if err := cfg.emit(ctx, "tls_get_certificate", map[string]any{"client_hello": clientHelloWithoutConn(clientHello)}); err != nil {
 			cfg.Logger.Error("TLS handshake aborted by event handler",
 				zap.String("server_name", clientHello.ServerName),


### PR DESCRIPTION
Closes #405.

## Problem

`GetCertificateWithContext` emits `tls_get_certificate` as its first statement:

```go
cfg.emit(ctx, "tls_get_certificate", map[string]any{"client_hello": clientHelloWithoutConn(clientHello)})
```

`emit` returns immediately when `OnEvent` is nil, but Go evaluates arguments first, so the map and the `serializableClientHello` copy are built on every handshake whether or not anything can receive them.

## Change

An optional `Config.ShouldEmitFunc` lets an embedder say whether an event is worth emitting. It is consulted through a small helper:

```go
func (cfg *Config) shouldEmit(eventName string) bool {
	if cfg.OnEvent == nil {
		return false
	}
	if cfg.ShouldEmitFunc == nil {
		return true // no way to ask; assume it is
	}
	return cfg.ShouldEmitFunc(eventName)
}
```

Four things worth calling out:

**Leaving the field unset keeps today's behavior exactly.** The middle branch is the one every existing user takes: with no way to ask, every event is emitted. Nothing changes for anyone who does not opt in.

**The predicate only comes along with the handler it was written for.** `newWithCache` inherits `ShouldEmitFunc` from `Default` only when it also inherited `OnEvent`; a caller that brings its own handler and no predicate keeps a nil one, rather than picking up an unrelated predicate that knows nothing about it. `TestShouldEmitFuncInheritedWithOnEvent` covers the three combinations.

**The check has to be at the call site.** `emit` already returns early on a nil `OnEvent`, but by the time it is entered its arguments exist. That is the whole problem, and it is why the guard cannot live inside `emit`. The helper's doc comment says so, to keep it from being "simplified" away later.

**Only the handshake is guarded.** The other twelve `emit` calls happen per certificate — caching, issuance, renewal, OCSP — where the data costs less than deciding whether to build it. Sprinkling the guard there would be noise.

## Benchmarks

`GetCertificate` against a cached certificate, with an `OnEvent` handler installed in both cases (Apple M2):

| | ns/op | B/op | allocs/op |
|---|--:|--:|--:|
| `GetCertificateEventSubscribed` | 1000 | 2848 | 24 |
| `GetCertificateEventUnsubscribed` | **777** | **2176** | **17** |

The 672 bytes and 7 allocations are exactly what building the event data costs; measured on its own it is 169 ns/op, 672 B/op, 7 allocs/op. This is not a full handshake — no TLS crypto, no I/O — so it isolates the lookup step.

## Tests

`TestShouldEmit` covers the five states of the two hooks, including that a nil `OnEvent` outweighs a subscriber claim. `TestGetCertificateSkipsUnobservedEvent` checks the behavior through `GetCertificate` for subscribed, unsubscribed, and no-way-to-ask. `TestGetCertificateHonorsEventAbort` pins down that a subscribed handler can still abort a handshake, which is the thing it would be worst to break silently.

## On the Caddy side

Caddy always installs an `OnEvent` hook, so the nil case alone would not help it. Its events app already keeps subscriptions per event name — caddyserver/caddy#7997 uses exactly that to shortcut dispatch — so `ShouldEmitFunc` would be a couple of lines there. I'll send that once this lands and Caddy picks up a release.

---

*Assistance disclosure: I investigated this with Claude Code (Claude Opus 5), which read the code paths, wrote the patch, the benchmarks and the tests, and ran the test suite. I directed the investigation, reviewed the change, and vetted it for correctness.*
